### PR TITLE
prepare envtest dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ includes:
 
 Adding new specialized tasks in addition to the imported generic ones is straightforward: simply add the task definitions in the importing Taskfile.
 
-It is also possible to exclude or overwrite generic tasks. The following example uses an `external-apis` task that should be executed as part of the generic `generate:code` task.
+It is also possible to exclude or overwrite generic tasks. The following example uses an `external-apis` task that should be executed as part of the generic `generate:code` task, and it adds a envtest dependency to the `validate:test` task.
 
 Overwriting basically works by excluding and re-defining the generic task that should be overwritten. If the generic task's logic should be kept as part of the overwritten definition, the generic file needs to be imported a second time with `internal: true`, so that the original task can be called.
 
@@ -128,6 +128,9 @@ includes:
 tasks:
   generate:code: # overwrites shared code task to add external API fetching
     desc: "  Generate code (mainly DeepCopy functions) and fetches external APIs."
+    aliases:
+    - gen:code
+    - g:code
     run: once
     cmds:
     - task: external-apis
@@ -135,7 +138,20 @@ tasks:
 
   external-apis:
     desc: "  Fetch external APIs."
+    run: once
     <...>
+    internal: true
+
+  validate:test: # overwrites the test task to add a dependency towards envtest
+    desc: "  Run all tests."
+    aliases:
+    - val:test
+    - v:test
+    run: once
+    deps:
+    - tools:envtest
+    cmds:
+    - task: c:validate:test
 ```
 
 ### Makefile

--- a/Taskfile_library.yaml
+++ b/Taskfile_library.yaml
@@ -58,6 +58,8 @@ vars:
   YAML2JSON_VERSION: '{{ .YAML2JSON_VERSION | default "v1.3.5" }}'
   OCM: '{{ .OCM | default (print .LOCALBIN "/ocm") }}'
   OCM_VERSION: '{{ .OCM_VERSION | default "v0.21.0" }}'
+  ENVTEST: '{{ .ENVTEST | default (print .LOCALTMP "/setup-envtest") }}'
+  ENVTEST_VERSION: '{{ .ENVTEST_VERSION | default "release-0.16" }}'
 
   DOCKER_BUILDER_NAME: # move to build taskfile later
     sh: 'echo -n ${DOCKER_BUILDER_NAME:-"openmcp-multiarch-builder"}'
@@ -98,13 +100,13 @@ tasks:
     desc: "  Combines all code generation tasks, including formatting."
     run: once
     deps:
-    - gen:generate
+    - generate:generate
   
   test:
     desc: "  Run all tests."
     run: once
     deps:
-    - val:test
+    - validate:test
   
   validate:
     desc: "  Combines all validation tasks except for tests."
@@ -113,7 +115,7 @@ tasks:
     - verify
     - check
     deps:
-    - val:validate
+    - validate:validate
   
   version:
     desc: "  Print the version of the project. Use VERSION_OVERRIDE to make this task print a specific version."

--- a/tasks_tools.yaml
+++ b/tasks_tools.yaml
@@ -157,3 +157,20 @@ tasks:
     - 'curl -sSfL https://ocm.software/install.sh | OCM_VERSION="{{.OCM_VERSION | trimPrefix "v"}}" bash -s "{{.tmpdir}}"'
     - 'mv "{{.tmpdir}}/ocm" "{{.OCM}}"'
     internal: true
+
+  envtest:
+    desc: "  Ensure that envtest is installed."
+    run: once
+    requires:
+      vars:
+      - ENVTEST
+      - ENVTEST_VERSION
+    deps:
+    - localbin
+    status:
+    - 'test -x "{{.ENVTEST}}"'
+    - test -f {{.LOCALBIN}}/envtest_version
+    - 'cat {{.LOCALBIN}}/envtest_version | grep -q "{{.ENVTEST_VERSION}}"'
+    cmds:
+    - 'GOBIN="{{.LOCALBIN}}" go install sigs.k8s.io/controller-runtime/tools/setup-envtest@{{.ENVTEST_VERSION}}'
+    internal: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Some repos might have tests that require an envtest dependency. This change adds an internal `tools:envtest` task to satisfy this dependency.