### PR TITLE
chore: remove sources.access.ref

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -71,7 +71,6 @@ sources:
     type: gitHub
     repoUrl: (( values.REPO_URL ))
     commit: (( values.COMMIT ))
-    ref: (( contains(values.VERSION, "-dev") ? ~~ :"refs/tags/" values.VERSION ))
 resources:
 - <<<: (( sum[funcs.splitIgnoreEmpty(",", funcs.ignoreDisabled(defaults.BP_COMPONENTS))|[]|s,comp|-> s *templates.blueprint] ))
 - <<<: (( sum[funcs.splitIgnoreEmpty(",", funcs.ignoreDisabled(defaults.CHART_COMPONENTS))|[]|s,cv|-> ("cvs" = split(":", cv)) ("comp" = cvs[0], "chart_version" = (cvs[1] || defaults.CHART_VERSION)) s *templates.chart] ))


### PR DESCRIPTION
`sources.access.ref` can no longer specified in conjuntion with `sources.access.commit`

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Remove sources.access.ref
```
