### PR TITLE
fix: use linux as default when builing image

### DIFF
--- a/Taskfile_library.yaml
+++ b/Taskfile_library.yaml
@@ -36,6 +36,8 @@ vars:
     sh: 'PROJECT_ROOT="{{.ROOT_DIR2}}" {{.TASKFILE_DIR2}}/get-version.sh'
   OS:
     sh: echo ${OS:-$(go env GOOS)}
+  IMAGE_OS:
+    sh: echo ${IMAGE_OS:-linux}
   ARCH:
     sh: echo ${ARCH:-$(go env GOARCH)}
   MODULE_NAME:

--- a/tasks_build_img.yaml
+++ b/tasks_build_img.yaml
@@ -30,27 +30,27 @@ tasks:
     internal: true
 
   build:
-    desc: "  Build the image for $OS/$ARCH."
+    desc: "  Build the image for $IMAGE_OS/$ARCH."
     summary: |
       This task builds the image for the current operating system and architecture.
-      To overwrite this, set the 'OS' and 'ARCH' environment variables.
+      To overwrite this, set the 'IMAGE_OS' and 'ARCH' environment variables.
       To overwrite the image's base path, set the 'IMAGE_REGISTRY' environment variable.
     deps:
     - task: build:bin:build
       vars:
-        OS: '{{.OS}}'
+        OS: '{{.IMAGE_OS}}'
         ARCH: '{{.ARCH}}'
     cmds:
     - task: build-raw
       vars:
-        OS: '{{.OS}}'
+        OS: '{{.IMAGE_OS}}'
         ARCH: '{{.ARCH}}'
 
   build-raw:
     desc: "  Build the image. Does not run the binary build before."
     summary: |
       This task builds the image for the current operating system and architecture.
-      To overwrite this, set the 'OS' and 'ARCH' environment variables.
+      To overwrite this, set the 'IMAGE_OS' and 'ARCH' environment variables.
       To overwrite the image's base path, set the 'IMAGE_REGISTRY' environment variable.
     requires:
       vars:
@@ -68,7 +68,7 @@ tasks:
       vars:
         COMPONENT: '{{.ITEM}}'
         IMAGE_BASE: '{{.IMAGE_BASE}}'
-        OS: '{{.OS}}'
+        OS: '{{.IMAGE_OS}}'
         ARCH: '{{.ARCH}}'
       task: build-internal
 
@@ -124,7 +124,7 @@ tasks:
     desc: "  Push the image. Image must have been built before."
     summary: |
       This task pushes the image for the current operating system and architecture.
-      To overwrite this, set the 'OS' and 'ARCH' environment variables.
+      To overwrite this, set the 'IMAGE_OS' and 'ARCH' environment variables.
       To overwrite the image's base path, set the 'IMAGE_REGISTRY' environment variable.
     requires:
       vars:
@@ -136,7 +136,7 @@ tasks:
         var: COMPONENTS
       vars:
         COMPONENT: '{{.ITEM}}'
-        OS: '{{.OS}}'
+        OS: '{{.IMAGE_OS}}'
         ARCH: '{{.ARCH}}'
       task: push-internal
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously the (non-multi) image tasks have build images based on the `OS` variable which was defaulted to `$(go env GOOS)`.
When run on macOS this resulted in `darwin`. Neither othe base image that is being used nor docker under macOS supports darwin images. In general docker always runs linux images even under macOS or windows in a virtual environment.
Therefore id doesn't make sense to build images based on the `$(go env GOOS)` result.

Instead there is now a seperate variable `IMAGE_OS` which is set to `linux` by default, but can be overwritten by the user.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Build linux images by default
```
