### PR TITLE
fix: add the repository owner as a input

### DIFF
--- a/.github/workflows/publish.lib.yaml
+++ b/.github/workflows/publish.lib.yaml
@@ -2,6 +2,11 @@ name: Publish
 
 on:
   workflow_call:
+    inputs:
+      owner:
+        description: 'Owner of the repository'
+        required: true
+        type: string
 
 permissions:
   packages: write
@@ -21,6 +26,7 @@ jobs:
           # required
           app-id: 1312871
           private-key: ${{ secrets.OPENMCP_CI_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.owner }}
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
**What this PR does / why we need it**:

The `owner` variable is no longer set in workflow call. It needs to be passed as an input parameter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Pass the owner variable as input parameter
```
