### PR TITLE
fix: disable validation for renovate user

### DIFF
--- a/.github/workflows/validate-pr-content.lib.yaml
+++ b/.github/workflows/validate-pr-content.lib.yaml
@@ -11,7 +11,15 @@ jobs:
       - name: Validate PR content
         run: |
           PR_BODY=$(jq -r .pull_request.body "$GITHUB_EVENT_PATH")
+          PR_USER=$(jq -r .pull_request.user.login "$GITHUB_EVENT_PATH")
           echo "DEBUG: PR_BODY content is: $PR_BODY"
+          echo "DEBUG: PR_USER is: $PR_USER"
+
+          if [ "$PR_USER" = "renovate" ]; then
+            echo "Validation skipped for user: $PR_USER"
+            exit 0
+          fi
+
           REQUIRED_SECTIONS=("\\*\\*What this PR does / why we need it\\*\\*:" "\\*\\*Release note\\*\\*:")
 
           for SECTION in "${REQUIRED_SECTIONS[@]}"; do


### PR DESCRIPTION
**What this PR does / why we need it**:

`renovate` doesn't use the pull request template. Therefore disable the validation when the creator of a PR is `renovate`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Disable PR validation for renovate user
```
