### PR TITLE
fix: create tags for all nested modules

### DIFF
--- a/.github/workflows/release.lib.yaml
+++ b/.github/workflows/release.lib.yaml
@@ -77,21 +77,12 @@ jobs:
           git tag -a "${{ env.version }}" -m "Release ${{ env.version }}"
           git push origin "${{ env.version }}"
 
-      - name: Create Git tag for api submodule
-        if: ${{ env.SKIP != 'true' }}
-        run: |
-          AUTHOR_NAME=$(git log -1 --pretty=format:'%an')
-          AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
-          echo "Tagging as $AUTHOR_NAME <$AUTHOR_EMAIL>"
+          NESTED_GO_MODULES="$(task release:list-nested-modules)"
 
-          echo "AUTHOR_NAME=$AUTHOR_NAME" >> $GITHUB_ENV
-          echo "AUTHOR_EMAIL=$AUTHOR_EMAIL" >> $GITHUB_ENV
-
-          git config user.name "$AUTHOR_NAME"
-          git config user.email "$AUTHOR_EMAIL"
-
-          git tag -a "api/${{ env.version }}" -m "Release ${{ env.version }}"
-          git push origin "api/${{ env.version }}"
+          for MODULE in $NESTED_GO_MODULES; do
+            git tag -a "${{MODULE}}/${{ env.version }}" -m "Release ${{ env.version }}"
+            git push origin "${{MODULE}}/${{ env.version }}"
+          done
 
       - name: Build Changelog
         id: github_release

--- a/tasks_rls.yaml
+++ b/tasks_rls.yaml
@@ -134,3 +134,8 @@ tasks:
     cmds:
     - '{{.TASKFILE_DIR2}}/sed.sh -E "s@	{{.MODULE_NAME}}/{{.MODULE}} .*@	{{.MODULE_NAME}}/{{.MODULE}} {{.VERSION}}@" "{{.ROOT_DIR2}}/go.mod"'
     internal: true
+
+  list-nested-modules:
+    desc: "List all nested modules in the project."
+    cmds:
+      - cmd: 'echo "{{.NESTED_MODULES}}"'


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously there was a static tag creation for the api submodule.
This PR changes this so that tags are created for all nested modules defined in the projects `Taskfile.yaml`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Create tags for all nested modules defined
```
