### PR TITLE
feat: when in a PR and created by PR attempt to add generated files

### DIFF
--- a/.github/workflows/ci.lib.yaml
+++ b/.github/workflows/ci.lib.yaml
@@ -26,6 +26,28 @@ jobs:
       - name: task generate
         run: |
           task generate --verbose
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            PR_USER=$(jq -r .pull_request.user.login "$GITHUB_EVENT_PATH")
+            if [ "$PR_USER" = "renovate[bot]" ]; then
+              echo "attempting to commit generated files"
+
+              AUTHOR_NAME=$(git log -1 --pretty=format:'%an')
+              AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
+              echo "Committing as $AUTHOR_NAME <$AUTHOR_EMAIL>"
+
+              echo "AUTHOR_NAME=$AUTHOR_NAME" >> $GITHUB_ENV
+              echo "AUTHOR_EMAIL=$AUTHOR_EMAIL" >> $GITHUB_ENV
+
+              git config user.name "$AUTHOR_NAME"
+              git config user.email "$AUTHOR_EMAIL"
+
+              git add -A
+              git commit -m "chore: regenerate files" || echo "No changes to commit"
+              git push origin "${{ github.head_ref }}" || echo "No changes to push"
+            fi
+          fi
+
           git diff --exit-code
 
       - name: task validate


### PR DESCRIPTION
**What this PR does / why we need it**:

When the code-generator version has changed the pull request validation will fail for all renovate PRs that are created for submodule updates. This results in a human user has to re-generate this files locally and push it to the PR manually.

This change attempts to add the generated files automatically only if the following conditions are met:

1. runs in a Pull Request
2. the Pull Request user is renovate

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Automatically add generated files to the pull request when created by renovate
```
