### PR TITLE
fix: handle release notes with NONE value correctly.

### DIFF
--- a/generate-changelog.sh
+++ b/generate-changelog.sh
@@ -57,11 +57,11 @@ for PR_NUMBER in $PR_COMMITS; do
   CLEAN_TITLE=$(echo "$TITLE" | sed -E 's/^[a-z]+(\([^)]+\))?(!)?:[[:space:]]+//')
 
   # Extract release note block, we only extract the "user" related notes.
-  RELEASE_NOTE=$(echo "$BODY" | awk '/^```[[:space:]]*(breaking|feature|bugfix|doc|other)[[:space:]]+user[[:space:]]*$/ {flag=1; next} /^```[[:space:]]*$/ {flag=0} flag' || true)
-
+  RELEASE_NOTE=$(echo "$BODY" | awk '/^```[[:space:]]*(breaking|feature|bugfix|doc|other)[[:space:]]+user[[:space:]]*$/ {flag=1; next} /^```[[:space:]]*$/ {flag=0} flag' | grep -v  'NONE' || true)
   # Format entry
   ENTRY="- $CLEAN_TITLE [#${PR_NUMBER}](${URL})"
-  if [[ -n "$RELEASE_NOTE"  || "$RELEASE_NOTE" != "NONE" ]]; then
+
+  if [[ -n "$RELEASE_NOTE" ]]; then
     ENTRY+=": $RELEASE_NOTE"
   else
     ENTRY+="."


### PR DESCRIPTION
**What this PR does / why we need it**:
When pulling the release notes for each PR, the release notes with NONE values where not handled correctly. This PR fixes this and treats those release notes and empty.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
