### PR TITLE
authenticate for task install action

### DIFF
--- a/.github/workflows/ci.lib.yaml
+++ b/.github/workflows/ci.lib.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: task generate
         run: |

--- a/.github/workflows/publish.lib.yaml
+++ b/.github/workflows/publish.lib.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read and validate VERSION
         id: version

--- a/.github/workflows/release.lib.yaml
+++ b/.github/workflows/release.lib.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read and validate VERSION
         id: version


### PR DESCRIPTION
**What this PR does / why we need it**:
We are seeing problems with rate limiting for installing the `task` tool.
According to the [documentation of the action](https://github.com/arduino/setup-task/blob/main/README.md), authenticating should increase it.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Is it a security risk to pass the token into a 3rd-party GHA? I tried to find out what exactly the action does, but for some reason, there is a 12000+ lines javascript file ...

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Use authentication for the `arduino/setup-task@v2` action to resolve problems with rate limiting.
```
