### PR TITLE
fix: Conventional Commit for release PR

### DIFF
--- a/tasks_rls.yaml
+++ b/tasks_rls.yaml
@@ -72,7 +72,7 @@ tasks:
     - vars:
         CLI_ARGS: '{{.RELEASE_VERSION}}'
       task: set-version
-    - '( cd "{{.ROOT_DIR2}}"; git add --all; git commit -m "release {{.RELEASE_VERSION}}" )'
+    - '( cd "{{.ROOT_DIR2}}"; git add --all; git commit -m "feat: release {{.RELEASE_VERSION}}" )'
     internal: true
 
   set-version:


### PR DESCRIPTION
**What this PR does / why we need it**:
will add the "feat: " prefix on commit message when running `task release:minor`
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

when calling `task release:minor`, the commit message is like "release v0.1.12" which then, when merging the PR, needs to manual adapt to semantic/conventional commit message.

This is a quick'n'dirty fix by adding the prefix "feat: " to the commit message, it could be adapted depending on major/minor/patch release like described in [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#how-does-this-relate-to-semver) 
My knowledge here is lacking, but probably one of you know how to quickly implement this?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
