### PR TITLE
fix: set version task

### DIFF
--- a/tasks_rls.yaml
+++ b/tasks_rls.yaml
@@ -132,7 +132,7 @@ tasks:
       - MODULE
       - MODULE_NAME
     cmds:
-    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@	{{.MODULE_NAME}}/{{.MODULE}} .*@	{{.MODULE_NAME}}/{{.MODULE}} {{.VERSION}}@" "{{.ROOT_DIR2}}/go.mod"'
+    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@	{{.MODULE_NAME}}/{{.MODULE}} v.*@	{{.MODULE_NAME}}/{{.MODULE}} {{.VERSION}}@" "{{.ROOT_DIR2}}/go.mod"'
     - for:
         var: NESTED_MODULES
       vars:
@@ -153,7 +153,7 @@ tasks:
       - VERSION
       - MODULE_NAME
     cmds:
-    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@	{{.MODULE_NAME}}/{{.MODULE_DEPENDENCY}} .*@	{{.MODULE_NAME}}/{{.MODULE_DEPENDENCY}} {{.VERSION}}@" "{{.ROOT_DIR2}}/{{.MODULE_TO_UPDATE}}/go.mod"'
+    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@	{{.MODULE_NAME}}/{{.MODULE_DEPENDENCY}} v.*@	{{.MODULE_NAME}}/{{.MODULE_DEPENDENCY}} {{.VERSION}}@" "{{.ROOT_DIR2}}/{{.MODULE_TO_UPDATE}}/go.mod"'
     internal: true
 
   list-nested-modules:


### PR DESCRIPTION
**What this PR does / why we need it**:
During a release of the openmcp-operator, the lines 
```
replace (
	github.com/openmcp-project/openmcp-operator/api => ./api
	github.com/openmcp-project/openmcp-operator/lib => ./lib
)
```
got replaced with
```
replace (
	github.com/openmcp-project/openmcp-operator/api <new_version>
	github.com/openmcp-project/openmcp-operator/lib <new_version>
)
```

This was due to a wrong regex, which was not expected to match these lines.

The problem didn't occur in the past and also not in other projects, because there we always have only a single `replace` statement, not a block, and the line needs to start with whitespace to be matched.

I added a `v` in the regex, so that it will now only match lines that have a version after the module path.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The `release:set-version` task had a bug that caused it to replace some lines in the `go.mod` file that it wasn't supposed to replace. This is now fixed.
```
