### PR TITLE
fix: release note indentation

### DIFF
--- a/generate-changelog.sh
+++ b/generate-changelog.sh
@@ -82,7 +82,7 @@ for PR_NUMBER in $PR_COMMITS; do
       NOTE_TYPE=$(jq -r '.type' <<< "$note" | tr '[:lower:]' '[:upper:]')
       NOTE_AUDIENCE=$(jq -r '.audience' <<< "$note" | tr '[:lower:]' '[:upper:]')
       NOTE_BODY=$(jq -r '.body' <<< "$note")
-      echo -en "\n  - **[$NOTE_AUDIENCE][$NOTE_TYPE]** $NOTE_BODY"
+      echo -en "\n  - **[$NOTE_AUDIENCE][$NOTE_TYPE]** ${NOTE_BODY//'\n'/'\n    '}" # the parameter expansion is required to fix the indentation
     done
   )"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the release note indentation. See below for examples.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
The release note
```
The validation for the `spec.iam.oidcProviders` field in the `ManagedControlPlaneV2` resource has been changed in multiple ways:
- `usernamePrefix` and `groupsPrefix` have been removed and are now always assumed to be `<name>:`
- `name` is not allowed to be set to `system` (prevents k8s service account impersonation)
- The regex validation rule for `name` has been fixed
- `issuer` and `clientID` are now required and the former one must look like an URL
- Duplicate OIDC provider names or ones that clash with the default OIDC provider are now prevented
```
was previously rendered as the following in the generated changelog (enclosed in horizontal lines for better visibility)

---
- <PR_HEADER>:
  - The validation for the `spec.iam.oidcProviders` field in the `ManagedControlPlaneV2` resource has been changed in multiple ways:
- `usernamePrefix` and `groupsPrefix` have been removed and are now always assumed to be `<name>:`
- `name` is not allowed to be set to `system` (prevents k8s service account impersonation)
- The regex validation rule for `name` has been fixed
- `issuer` and `clientID` are now required and the former one must look like an URL
- Duplicate OIDC provider names or ones that clash with the default OIDC provider are now prevented
---
and is now correctly rendered as

---
- <PR_HEADER>:
  - The validation for the `spec.iam.oidcProviders` field in the `ManagedControlPlaneV2` resource has been changed in multiple ways:
    - `usernamePrefix` and `groupsPrefix` have been removed and are now always assumed to be `<name>:`
    - `name` is not allowed to be set to `system` (prevents k8s service account impersonation)
    - The regex validation rule for `name` has been fixed
    - `issuer` and `clientID` are now required and the former one must look like an URL
    - Duplicate OIDC provider names or ones that clash with the default OIDC provider are now prevented
---

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fixed a bug that caused multiline release notes to be wrongly indented in the generated changelog.
```
