### PR TITLE
enable release version increases for additional helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Since the imported Taskfile is generic, there are a few variables that need to b
   - See below for a short documentation of the the index generation.
 - `ENVTEST_REQUIRED`
   - If this is set to `true`, the `test` task will include the `setup-envtest` tooling in its dependencies and download it automatically.
+- `ADDITIONAL_CHARTS`
+  - Can be set to multiple paths (separated by space) to helm chart directories. The versions in these charts' `Chart.yaml` and `values.yaml` will be increased during releases.
+  - Note that the charts for each module (located at `charts/<module>`) will always have their version increased and do not need to be listed here.
 
 There are two main Taskfiles, one of which should be included:
 - `Taskfile_controller.yaml` is meant for operator repositories and contains task definitions for code generation and validation, binary builds, and image builds.

--- a/Taskfile_library.yaml
+++ b/Taskfile_library.yaml
@@ -50,7 +50,7 @@ vars:
     sh: 'cat "{{.ROOT_DIR2}}/go.mod" | grep "module " | sed "s/module //" | sed -E "s/[[:blank:]].*//"'
   NESTED_MODULES: '{{.NESTED_MODULES | default "" }}'
   DOCKERFILE: '{{.DOCKERFILE | default (print .TASKFILE_DIR2 "/Dockerfile") }}'
-
+  ADDITIONAL_CHARTS: '{{.ADDITIONAL_CHARTS | default "" }}'
 
   LOCALBIN: '{{ env "LOCALBIN" | default ( .LOCALBIN | default (print .ROOT_DIR2 "/bin") ) }}'
   LOCALTMP: '{{ env "LOCALTMP" | default ( .LOCALTMP | default (print .ROOT_DIR2 "/tmp") ) }}'

--- a/tasks_rls.yaml
+++ b/tasks_rls.yaml
@@ -103,6 +103,12 @@ tasks:
         VERSION: '{{.VERSION}}'
       task: set-chart-version-internal
     - for:
+        var: ADDITIONAL_CHARTS
+      vars:
+        CHART_PATH: '{{.ITEM}}'
+        VERSION: '{{.VERSION}}'
+      task: set-chart-version-internal-raw
+    - for:
         var: NESTED_MODULES
       vars:
         MODULE: '{{.ITEM}}'
@@ -118,9 +124,23 @@ tasks:
       - VERSION
       - COMPONENT
     cmds:
-    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@version: v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*@version: {{.VERSION}}@1" "{{.ROOT_DIR2}}/charts/{{.COMPONENT}}/Chart.yaml"'
-    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@appVersion: v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*@appVersion: {{.VERSION}}@1" "{{.ROOT_DIR2}}/charts/{{.COMPONENT}}/Chart.yaml"'
-    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@  tag: .*@  tag: {{.VERSION}}@" "{{.ROOT_DIR2}}/charts/{{.COMPONENT}}/values.yaml"'
+    - vars:
+        VERSION: '{{.VERSION}}'
+        CHART_PATH: '{{.ROOT_DIR2}}/charts/{{.COMPONENT}}'
+      task: set-chart-version-internal-raw
+    internal: true
+
+  set-chart-version-internal-raw:
+    desc: "  Sets the versions in the helm chart at a specific path."
+    run: always
+    requires:
+      vars:
+      - VERSION
+      - CHART_PATH
+    cmds:
+    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@version: v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*@version: {{.VERSION}}@1" "{{.CHART_PATH}}/Chart.yaml"'
+    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@appVersion: v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*@appVersion: {{.VERSION}}@1" "{{.CHART_PATH}}/Chart.yaml"'
+    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@  tag: .*@  tag: {{.VERSION}}@" "{{.CHART_PATH}}/values.yaml"'
     internal: true
 
   set-module-version-internal:


### PR DESCRIPTION
**What this PR does / why we need it**:
We are currently migrating the landscaper repos to using this repo. Some of the landscaper repos use multiple helm charts. This change enables version increases during releases for additional helm charts (outside of `charts/<module`).

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Versions in additional helm charts can now be automatically increased by specifying the paths to the chart directories in the main taskfile's `ADDITIONAL_CHARTS` variable.
```
