### PR TITLE
fix: use same go.mod file for changelog generation as for binary building

### DIFF
--- a/.github/workflows/release.lib.yaml
+++ b/.github/workflows/release.lib.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug that could potentially break the release workflow, see https://github.com/openmcp-project/project-workspace-operator/actions/runs/19965004342/job/57254391021 for example.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The release workflow now uses the same go version as the publish one.
```
