### PR TITLE
feat: add renovate task generate workflow

### DIFF
--- a/.github/workflows/renovate-generate.lib.yaml
+++ b/.github/workflows/renovate-generate.lib.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 name: Renovate Generate (lib)
 
 on:

--- a/.github/workflows/renovate-generate.lib.yaml
+++ b/.github/workflows/renovate-generate.lib.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Renovate Generate (lib)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        id: app-token
+        with:
+          app-id: 1312871
+          private-key: ${{ secrets.OPENMCP_CI_APP_PRIVATE_KEY }}
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
+          ref: ${{ github.ref_name }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run task generate
+        run: task generate --verbose
+
+      - name: Commit generated files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet || (git add -A && git commit -m "chore: regenerate after dependency update" && git push)

--- a/README.md
+++ b/README.md
@@ -161,6 +161,51 @@ To re-use it, simply create a symbolic link from the importing repo:
 ln -s ./hack/common/Makefile Makefile
 ```
 
+## GitHub Actions Workflows
+
+This repository provides reusable GitHub Actions workflows that can be called from downstream repositories.
+
+### Available Workflows
+
+| Workflow | Purpose |
+|---|---|
+| `ci.lib.yaml` | Runs code generation, validation, and tests |
+| `publish.lib.yaml` | Builds and publishes images, charts, and OCM components |
+| `release.lib.yaml` | Creates releases and tags |
+| `renovate-generate.lib.yaml` | Runs `task generate` on Renovate branches and commits the result |
+
+### Renovate: Auto-generate after dependency updates
+
+When Renovate updates a dependency (e.g. Go module, tool version), files like CRD manifests or generated code may need to be regenerated. The `renovate-generate.lib.yaml` workflow handles this automatically: it triggers on pushes to `renovate/**` branches, runs `task generate`, and commits any changed files back to the branch.
+
+To use it, add the following workflow to the downstream repository:
+
+```yaml
+# .github/workflows/renovate-generate.yaml
+name: Renovate Generate
+
+on:
+  push:
+    branches:
+      - "renovate/**"
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    uses: openmcp-project/build/.github/workflows/renovate-generate.lib.yaml@main
+    secrets: inherit
+```
+
+Also add the following to the repository's `renovate.json`. This tells Renovate to ignore commits from `github-actions[bot]` when determining whether a branch has been modified externally, which is necessary to keep `:rebaseStalePrs` working correctly:
+
+```json
+"gitIgnoredAuthors": [
+  "github-actions[bot]@users.noreply.github.com"
+]
+```
+
 ## Documentation Index Generation
 
 This repository contains a script for creating a index for the documentation of the importing repository. This script is not executed by default, only if the `GENERATE_DOCS_INDEX` variable is explicitly set to anything except `false` in the importing Taskfile. Doing so will not only activate the documentation index generation, but also a check whether it is up-to-date during the `validate:docs` task.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds are shared workflow that runs `task generate` in updates in renovate branches.
This should prevent non-mergable renovate PRs because the generated files are different after re-generate in validation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Shared renovate workflow that runs `task generate` after renovate branch updates
```
