### PR TITLE
feat: enable build submodule for CLI repos

### DIFF
--- a/.github/workflows/homebrew.lib.yaml
+++ b/.github/workflows/homebrew.lib.yaml
@@ -10,11 +10,6 @@ on:
         required: false
         default: 1312871 # OpenMCP CI GitHub App
         type: string
-      app_private_key_secret_name:
-        description: 'GitHub App private key secret name for creating a GitHub App token'
-        required: false
-        default: OPENMCP_CI_APP_PRIVATE_KEY
-        type: string
       username:
         description: 'GitHub username of the homebrew tap owner/org'
         required: true
@@ -33,6 +28,10 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      app_private_key:
+        description: 'GitHub App private key for creating a GitHub App token.'
+        required: false
 
 jobs:
   homebrew-releaser:
@@ -45,7 +44,7 @@ jobs:
         with:
           # required
           app-id: ${{ inputs.app_id }}
-          private-key: ${{ secrets[inputs.app_private_key_secret_name] }}
+          private-key: ${{ case( secrets.app_private_key != '', secrets.app_private_key, secrets.OPENMCP_CI_APP_PRIVATE_KEY ) }}
 
       - name: Release project to Homebrew tap
         uses: Justintime50/homebrew-releaser@v3

--- a/.github/workflows/homebrew.lib.yaml
+++ b/.github/workflows/homebrew.lib.yaml
@@ -5,16 +5,22 @@ name: Homebrew Releaser
 on:
   workflow_call:
     inputs:
+      app_id:
+        description: 'GitHub App ID for creating a GitHub App token'
+        required: false
+        default: 1312871 # OpenMCP CI GitHub App
+        type: string
+      app_private_key_secret_name:
+        description: 'GitHub App private key secret name for creating a GitHub App token'
+        required: false
+        default: OPENMCP_CI_APP_PRIVATE_KEY
+        type: string
       username:
         description: 'GitHub username of the homebrew tap owner/org'
         required: true
         type: string
       tap:
         description: 'Name of the homebrew tap (must start with homebrew-)'
-        required: true
-        type: string
-      secret_name:
-        description: 'Name of the GitHub access token with repo permissions for the homebrew tap repository and the repository containing the project to be released'
         required: true
         type: string
       binary:
@@ -33,13 +39,21 @@ jobs:
     runs-on: ubuntu-24.04
     name: Update Homebrew Tap Formula
     steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        id: app-token
+        with:
+          # required
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets[inputs.app_private_key_secret_name] }}
+
       - name: Release project to Homebrew tap
         uses: Justintime50/homebrew-releaser@v3
         with:
           homebrew_owner: ${{ inputs.username }}
           homebrew_tap: ${{ inputs.tap }}
 
-          github_token: ${{ secrets[inputs.secret_name] }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
           # This expects the binary contained in the release artifact tarball to be named as the repository.
           install: |

--- a/.github/workflows/homebrew.lib.yaml
+++ b/.github/workflows/homebrew.lib.yaml
@@ -1,0 +1,57 @@
+# This workflow is meant to be triggered when a release is published.
+# It takes tarballed binaries from the release and updates a homebrew tap repository with a formula for the release.
+name: Homebrew Releaser
+
+on:
+  workflow_call:
+    inputs:
+      username:
+        description: 'GitHub username of the homebrew tap owner/org'
+        required: true
+        type: string
+      tap:
+        description: 'Name of the homebrew tap (must start with homebrew-)'
+        required: true
+        type: string
+      secret_name:
+        description: 'Name of the GitHub access token with repo permissions for the homebrew tap repository and the repository containing the project to be released'
+        required: true
+        type: string
+      binary:
+        description: 'Name of the binary, as contained in the release artifact tarball. Defaults to the repository name, if not specified.'
+        required: false
+        default: '${{ github.event.repository.name }}'
+        type: string
+      readme_table:
+        description: 'Whether to update the homebrew tap README with a table of available formulae. Must be set to false for the first run, as the action computes the table before adding the new formula.'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  homebrew-releaser:
+    runs-on: ubuntu-24.04
+    name: Update Homebrew Tap Formula
+    steps:
+      - name: Release project to Homebrew tap
+        uses: Justintime50/homebrew-releaser@v3
+        with:
+          homebrew_owner: ${{ inputs.username }}
+          homebrew_tap: ${{ inputs.tap }}
+
+          github_token: ${{ secrets[inputs.secret_name] }}
+
+          # This expects the binary contained in the release artifact tarball to be named as the repository.
+          install: |
+            bin.install "${{ inputs.binary }}"
+
+          # For each of these which is true, a corresponding <name>-<version(no v prefix)>-<os>-<arch>.tar.gz file containing a binary must be attached to the release.
+          target_darwin_amd64: true
+          target_darwin_arm64: true
+          target_linux_amd64: true
+          target_linux_arm64: true
+
+          # This can be used to inject a table of the available formulae into the homebrew tap's README.
+          # For some reason, it computes the table _before_ adding the new formula, which also causes it to fail if there is not yet a formula in the tap,
+          # meaning this must be false for the first run.
+          update_readme_table: ${{ inputs.readme_table }}

--- a/.github/workflows/homebrew.lib.yaml
+++ b/.github/workflows/homebrew.lib.yaml
@@ -5,11 +5,6 @@ name: Homebrew Releaser
 on:
   workflow_call:
     inputs:
-      app_id:
-        description: 'GitHub App ID for creating a GitHub App token'
-        required: false
-        default: 1312871 # OpenMCP CI GitHub App
-        type: string
       username:
         description: 'GitHub username of the homebrew tap owner/org'
         required: true
@@ -29,8 +24,9 @@ on:
         default: false
         type: boolean
     secrets:
-      app_private_key:
-        description: 'GitHub App private key for creating a GitHub App token.'
+      token:
+        # It seems that the homebrew releaser action cannot handle app tokens, so we need to do this differently than for the other actions.
+        description: 'Personal access token with repo access for the homebrew tap repository.'
         required: false
 
 jobs:
@@ -38,21 +34,13 @@ jobs:
     runs-on: ubuntu-24.04
     name: Update Homebrew Tap Formula
     steps:
-      - name: Create GitHub App token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
-        id: app-token
-        with:
-          # required
-          app-id: ${{ inputs.app_id }}
-          private-key: ${{ case( secrets.app_private_key != '', secrets.app_private_key, secrets.OPENMCP_CI_APP_PRIVATE_KEY ) }}
-
       - name: Release project to Homebrew tap
         uses: Justintime50/homebrew-releaser@v3
         with:
           homebrew_owner: ${{ inputs.username }}
           homebrew_tap: ${{ inputs.tap }}
 
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ secrets.token }}
 
           # This expects the binary contained in the release artifact tarball to be named as the repository.
           install: |

--- a/.github/workflows/publish.lib.yaml
+++ b/.github/workflows/publish.lib.yaml
@@ -8,11 +8,10 @@ on:
         required: false
         default: 1312871 # OpenMCP CI GitHub App
         type: string
-      app_private_key_secret_name:
-        description: 'GitHub App private key secret name for creating a GitHub App token'
+    secrets:
+      app_private_key:
+        description: 'GitHub App private key for creating a GitHub App token.'
         required: false
-        default: OPENMCP_CI_APP_PRIVATE_KEY
-        type: string
   
 permissions:
   packages: write
@@ -31,7 +30,7 @@ jobs:
         with:
           # required
           app-id: ${{ inputs.app_id }}
-          private-key: ${{ secrets[inputs.app_private_key_secret_name] }}
+          private-key: ${{ case( secrets.app_private_key != '', secrets.app_private_key, secrets.OPENMCP_CI_APP_PRIVATE_KEY ) }}
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/publish.lib.yaml
+++ b/.github/workflows/publish.lib.yaml
@@ -2,6 +2,17 @@ name: Publish
 
 on:
   workflow_call:
+    inputs:
+      app_id:
+        description: 'GitHub App ID for creating a GitHub App token'
+        required: false
+        default: 1312871 # OpenMCP CI GitHub App
+        type: string
+      app_private_key_secret_name:
+        description: 'GitHub App private key secret name for creating a GitHub App token'
+        required: false
+        default: OPENMCP_CI_APP_PRIVATE_KEY
+        type: string
   
 permissions:
   packages: write
@@ -19,8 +30,8 @@ jobs:
         id: app-token
         with:
           # required
-          app-id: 1312871
-          private-key: ${{ secrets.OPENMCP_CI_APP_PRIVATE_KEY }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets[inputs.app_private_key_secret_name] }}
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.lib.yaml
+++ b/.github/workflows/release.lib.yaml
@@ -3,6 +3,16 @@ name: Versioned Release
 on:
   workflow_call:
     inputs:
+      app_id:
+        description: 'GitHub App ID for creating a GitHub App token'
+        required: false
+        default: 1312871 # OpenMCP CI GitHub App
+        type: string
+      app_private_key_secret_name:
+        description: 'GitHub App private key secret name for creating a GitHub App token'
+        required: false
+        default: OPENMCP_CI_APP_PRIVATE_KEY
+        type: string
       is_cli:
         description: 'Indicates if this workflow is for a CLI tool (instead of a controller). If set, the built binaries will be attached to the release as artifacts.'
         required: false
@@ -23,8 +33,8 @@ jobs:
         id: app-token
         with:
           # required
-          app-id: 1312871
-          private-key: ${{ secrets.OPENMCP_CI_APP_PRIVATE_KEY }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets[inputs.app_private_key_secret_name] }}
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.lib.yaml
+++ b/.github/workflows/release.lib.yaml
@@ -24,6 +24,22 @@ permissions:
   pull-requests: read
 
 jobs:
+  verify_secret:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify secrets
+        run: |
+          echo "app id: ${{ inputs.app_id }}"
+          if [[ -z "${{ inputs.app_id }}" ]]; then
+            echo "app id is not set"
+            exit 1
+          fi
+          echo "app private key secret name: ${{ inputs.app_private_key_secret_name }}"
+          if [[ -z "${{ secrets[inputs.app_private_key_secret_name] }}" ]]; then
+            echo "app private key is not set"
+            exit 1
+          fi
+          echo "All required secrets are set"
   release_tag:
     name: Release version
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.lib.yaml
+++ b/.github/workflows/release.lib.yaml
@@ -2,6 +2,12 @@ name: Versioned Release
 
 on:
   workflow_call:
+    inputs:
+      is_cli:
+        description: 'Indicates if this workflow is for a CLI tool (instead of a controller). If set, the built binaries will be attached to the release as artifacts.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write # we need this to be able to push tags
@@ -92,7 +98,12 @@ jobs:
             git push origin "${MODULE}/${{ env.version }}"
           done
 
+      - name: Generate release artifacts
+        if: ${{ ( env.SKIP != 'true' ) && inputs.is_cli }}
+        run: task r:artifacts --verbose  
+
       - name: Build Changelog
+        if: ${{ env.SKIP != 'true' }}
         id: github_release  
         run: task r:generate-changelog
         env:
@@ -107,15 +118,14 @@ jobs:
           body_path: ./CHANGELOG.md
           draft: true
           prerelease: false
+          files: ${{ fromJSON('["", "./bin/release/*"]')[inputs.is_cli] }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push dev VERSION
         if: ${{ env.SKIP != 'true' }}
         run: |
-          task release:set-version --verbose -- "${{ env.version }}-dev"
           git config user.name "${{ env.AUTHOR_NAME }}"
           git config user.email "${{ env.AUTHOR_EMAIL }}"
-          git add VERSION
-          git commit -m "chore(release): Update VERSION to ${{ env.version }}-dev"
+          task r:prepare-dev-cycle --verbose
           git push origin main

--- a/.github/workflows/release.lib.yaml
+++ b/.github/workflows/release.lib.yaml
@@ -8,38 +8,21 @@ on:
         required: false
         default: 1312871 # OpenMCP CI GitHub App
         type: string
-      app_private_key_secret_name:
-        description: 'GitHub App private key secret name for creating a GitHub App token'
-        required: false
-        default: OPENMCP_CI_APP_PRIVATE_KEY
-        type: string
       is_cli:
         description: 'Indicates if this workflow is for a CLI tool (instead of a controller). If set, the built binaries will be attached to the release as artifacts.'
         required: false
         default: false
         type: boolean
+    secrets:
+      app_private_key:
+        description: 'GitHub App private key for creating a GitHub App token.'
+        required: false
 
 permissions:
   contents: write # we need this to be able to push tags
   pull-requests: read
 
 jobs:
-  verify_secret:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify secrets
-        run: |
-          echo "app id: ${{ inputs.app_id }}"
-          if [[ -z "${{ inputs.app_id }}" ]]; then
-            echo "app id is not set"
-            exit 1
-          fi
-          echo "app private key secret name: ${{ inputs.app_private_key_secret_name }}"
-          if [[ -z "${{ secrets[inputs.app_private_key_secret_name] }}" ]]; then
-            echo "app private key is not set"
-            exit 1
-          fi
-          echo "All required secrets are set"
   release_tag:
     name: Release version
     runs-on: ubuntu-24.04
@@ -50,7 +33,7 @@ jobs:
         with:
           # required
           app-id: ${{ inputs.app_id }}
-          private-key: ${{ secrets[inputs.app_private_key_secret_name] }}
+          private-key: ${{ case( secrets.app_private_key != '', secrets.app_private_key, secrets.OPENMCP_CI_APP_PRIVATE_KEY ) }}
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/renovate-generate.lib.yaml
+++ b/.github/workflows/renovate-generate.lib.yaml
@@ -2,6 +2,17 @@ name: Renovate Generate (lib)
 
 on:
   workflow_call:
+    inputs:
+      app_id:
+        description: 'GitHub App ID for creating a GitHub App token'
+        required: false
+        default: 1312871 # OpenMCP CI GitHub App
+        type: string
+    secrets:
+      app_private_key:
+        description: 'GitHub App private key for creating a GitHub App token.'
+        required: false
+
 
 permissions:
   contents: write
@@ -15,8 +26,8 @@ jobs:
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
         id: app-token
         with:
-          app-id: 1312871
-          private-key: ${{ secrets.OPENMCP_CI_APP_PRIVATE_KEY }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ case( secrets.app_private_key != '', secrets.app_private_key, secrets.OPENMCP_CI_APP_PRIVATE_KEY ) }}
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Instead of `make`, we have decided to use the [task](https://taskfile.dev/) tool
 
 It is strongly recommended to include this submodule under the `hack/common` path in the operator repositories. While most of the coding is designed to work from anywhere within the including repository, there are some workarounds for bugs in `task` which rely on the assumption that this repo is a submodule under `hack/common` in the including repository.
 
-## Setup
+## General Setup
 
 To use this repository, first check it out via
 ```shell
@@ -28,7 +28,13 @@ and ensure that it is checked-out via
 git submodule init
 ```
 
-### Taskfile
+## Variants
+
+These shared build tools can be used for repositories containing k8s controllers, as well as for ones that contain CLI tools. There are differences between both use-cases, a k8s controller needs an container image and might have a helm chart, while neither is the case for a CLI tool, which might want to attach its binaries to the github release instead, for example. The following sections describe the specifics for both variants.
+
+### Controller/Library Variant
+
+#### Taskfile
 
 To use the generic Taskfile contained in this repository, create a `Taskfile.yaml` in the including repository. It should look something like this:
 ```yaml
@@ -106,7 +112,41 @@ includes:
     flatten: true
 ```
 
-#### Overwriting and Excluding Task Definitions
+#### Requirements
+
+The controller variant of the Taskfile is able to handle multiple 'components' (= controller binaries) within the same repositories, but it expects a certain format for filepaths:
+- Each component must have its `main.go` file at `cmd/<component>/main.go`.
+- If the component has a helm chart, it must be under `charts/<component>`.
+
+### CLI Variant
+
+#### Taskfile
+
+CLI repos must use the `Taskfile_cli.yaml` instead:
+```yaml
+version: 3
+
+includes:
+  shared:
+    taskfile: hack/common/Taskfile_cli.yaml
+    flatten: true
+    vars:
+      CODE_DIRS: '{{.ROOT_DIR}}/cmd/... {{.ROOT_DIR}}/internal/... {{.ROOT_DIR}}/lib/...'
+      NESTED_MODULES: 'lib'
+      NAME: 'ocp'
+      REPO_NAME: 'https://github.com/openmcp-project/ocp'
+      GENERATE_DOCS_INDEX: "true"
+```
+
+Most variables in the Taskfile behave exactly like for the controller variant, especially `CODE_DIRS`, `NESTED_MODULES`, and `REPO_NAME`. As a new variable, `NAME` has to be set to the name the CLI should be published under (`ocp` in the above example).
+
+#### Requirements
+
+The CLI taskfile currently supports only one binary per repository and its `main.go` file has to be at top-level within the repository (this also enables the tool to be installed via `go install`, as long as it does not contain any `replace` directives within its `go.mod` file).
+
+## Further Taskfile Information
+
+### Overwriting and Excluding Task Definitions
 
 Adding new specialized tasks in addition to the imported generic ones is straightforward: simply add the task definitions in the importing Taskfile.
 
@@ -173,6 +213,7 @@ This repository provides reusable GitHub Actions workflows that can be called fr
 | `publish.lib.yaml` | Builds and publishes images, charts, and OCM components |
 | `release.lib.yaml` | Creates releases and tags |
 | `renovate-generate.lib.yaml` | Runs `task generate` on Renovate branches and commits the result |
+| `homebrew.lib.yaml` | Makes the binary available via a custom homebrew tap (CLI variant only) |
 
 ### Renovate: Auto-generate after dependency updates
 
@@ -206,7 +247,51 @@ Also add the following to the repository's `renovate.json`. This tells Renovate 
 ]
 ```
 
-## Documentation Index Generation
+### Homebrew Workflow
+
+The widely known package manager `homebrew` supports custom package repositories (called 'taps'), which are basically just github repositories that follow a specific structure. Usually, they contain a `Formula` folder which contains scripts for each package ('formula') that is available via the tap. This repository contains a github workflow which can be used to make a CLI tool available via a homebrew tap.
+
+For the workflow to work, a github secret needs to be available, containing an access token that has 'repo' permissions for both the CLI repo as well as the homebrew tap repo.
+
+The homebrew tap repo's name must be prefixed with `homebrew-`.
+
+The workflow can then be reused like this:
+```yaml
+name: Homebrew Releaser
+
+on:
+  release:
+    types:
+    - published
+
+jobs:
+  homebrew:
+    uses: openmcp-project/build/.github/workflows/homebrew.lib.yaml@main
+    secrets: inherit
+    with:
+      username: <user/org name of homebrew tap repo owner>
+      tap: <homebrew tap repo name> # must start with 'homebrew-'
+      secret_name: <name of github secret containing the access token>
+      binary: <binary name> # optional
+      readme_table: false # optional
+```
+
+The binary name argument is optional. It specifies under which name the tool will be available in the homebrew tap. It has to match the name of the binary contained in the tarball attached to the release which triggered the workflow. This corresponds to the `NAME` variable that has to be specified in the CLI variant taskfile. If not specified, the workflow assumes this to be identical to the repository name.
+
+The github action that is used to manage the homebrew tap is also able to render a table listing all formulae of the tap into the tap repo's README. This requires a placeholder like this within the README:
+```markdown
+<!-- project_table_start -->
+TABLE HERE
+<!-- project_table_end -->
+```
+> [!NOTE]
+> For some reason, the action computes the table _before_ adding the calling repo's formula and it fails if there are no formulae within the tap, which means
+>   - table generation must be disabled for the first run, if the homebrew tap repo does not have any formulae yet
+>   - when a new formula is added, it will only appear in the table when the workflow is run again _after_ the run that added the new formula
+
+## Documentation Generation
+
+### Documentation Index
 
 This repository contains a script for creating a index for the documentation of the importing repository. This script is not executed by default, only if the `GENERATE_DOCS_INDEX` variable is explicitly set to anything except `false` in the importing Taskfile. Doing so will not only activate the documentation index generation, but also a check whether it is up-to-date during the `validate:docs` task.
 
@@ -218,7 +303,42 @@ The metadata file is named `.docnames` and is expected to be JSON-formatted, con
 
 Additional fields in the JSON object can be used to manipulate the entries for markdown files within the directory: An entry `"foo.md": "Bar"` in the object causes the `foo.md` file in the directory to be displayed as `Bar` in the generated index. Setting the value of such an entry to the empty string removes the corresponding file from the index.
 
-Markdown files whose name is not overwritten by a corresponding field in the metadata file are named according to the first line starting with `# ` in their content, or ignored if the name cannot be determined this way.
+Markdown files whose name is not overwritten by a corresponding field in the metadata file are named according to the first line starting with `# ` (or `## `) in their content, or ignored if the name cannot be determined this way.
+
+### Command Reference Generation (CLI only)
+
+The [cobra](https://github.com/spf13/cobra) framework, which is commonly used for CLI tool implementation, comes with the possibility to generate a markdown command reference. This can be automatically executend by the `generate:command-reference` task, which is part of the `generate` task. The reference generation requires a file like this
+```go
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra/doc"
+
+	"<my-cli-module>/cmd"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		panic("documentation folder path required as argument")
+	}
+	if err := doc.GenMarkdownTree(cmd.NewMyCommand(), os.Args[1]); err != nil {
+		panic(err)
+	}
+}
+```
+where `cmd.NewMyCommand()` returns the root `cobra.Command`.
+
+By default, this file is expected under `hack/cmdref/main.go`, but this location can be customized by setting the `REFERENCE_GENERATOR` variable in the taskfile.
+
+The command reference will be generated into `docs/reference`. While the reference generation creates the folder, if it doesn't exist, note that the `.docnames` file has to be added to it manually, if the command reference should appear in the documentation index (see above). This only needs to be done once.
+
+> [!IMPORTANT]
+> By default, the cobra reference generation adds a timestamp to each generated markdown file, which causes all of them to change every time the code generation is run, which causes a lot of irrelevant git changes. This behavior can be disabled by setting the `DisableAutoGenTag` to `true` in the `cobra.Command` that is is passed into `doc.GenMarkdownTree`.
+
+> [!NOTE]
+> While initially implemented for the `cobra` reference generation, `task generate:command-reference` actually just calls the go main file at the `REFERENCE_GENERATOR` path. This leaves the option to use some other tool or custom logic to generate the command reference. The generator gets one argument, which is the path to the folder where the command reference should be generated into.
 
 #### Limitations
 

--- a/README.md
+++ b/README.md
@@ -251,8 +251,6 @@ Also add the following to the repository's `renovate.json`. This tells Renovate 
 
 The widely known package manager `homebrew` supports custom package repositories (called 'taps'), which are basically just github repositories that follow a specific structure. Usually, they contain a `Formula` folder which contains scripts for each package ('formula') that is available via the tap. This repository contains a github workflow which can be used to make a CLI tool available via a homebrew tap.
 
-For the workflow to work, a github secret needs to be available, containing an access token that has 'repo' permissions for both the CLI repo as well as the homebrew tap repo.
-
 The homebrew tap repo's name must be prefixed with `homebrew-`.
 
 The workflow can then be reused like this:
@@ -271,7 +269,6 @@ jobs:
     with:
       username: <user/org name of homebrew tap repo owner>
       tap: <homebrew tap repo name> # must start with 'homebrew-'
-      secret_name: <name of github secret containing the access token>
       binary: <binary name> # optional
       readme_table: false # optional
 ```

--- a/Taskfile_cli.yaml
+++ b/Taskfile_cli.yaml
@@ -1,0 +1,48 @@
+version: 3
+
+# This Taskfile is meant to be included for CLI repos.
+# In addition to the library tasks, it contains tasks for building binaries installing the CLI tool.
+
+run: once
+method: checksum
+
+includes:
+  lib:
+    taskfile: Taskfile_library.yaml
+    vars:
+      IS_CLI: true
+    flatten: true
+  build:
+    taskfile: tasks_cli_build.yaml
+    aliases:
+    - bld
+    - b
+
+tasks:
+
+  # The following tasks are non-namespaced aliases for the most important namespaced tasks.
+  # This helps with visibility on 'task -l'.
+
+  install:
+    desc: "  Install the CLI tool."
+    run: once
+    cmds:
+    - 'CGO_ENABLED=0 go install -ldflags="-X {{.MODULE_NAME}}/internal/version.buildVersion={{.VERSION}} -X {{.MODULE_NAME}}/internal/version.gitTreeState={{.GIT_TREE_STATE}} -X {{.MODULE_NAME}}/internal/version.gitCommit={{.GIT_COMMIT}} -X {{.MODULE_NAME}}/internal/version.buildDate={{.BUILD_DATE}}" "{{.ROOT_DIR2}}"'
+
+  build:
+    desc: "  Build the binaries. Includes code generation and validation."
+    summary: This is an alias for 'build:all'.
+    run: once
+    deps:
+    - task: build:all
+      vars:
+        IS_CLI: true
+
+  build-raw:
+    desc: "  Like 'build', but skips code generation/validation tasks."
+    summary: This is an alias for 'build:build-multi-raw'.
+    run: once
+    deps:
+    - task: build:build-multi-raw
+      vars:
+        IS_CLI: true

--- a/Taskfile_library.yaml
+++ b/Taskfile_library.yaml
@@ -33,7 +33,7 @@ vars:
     sh: 'if [[ "{{.TASKFILE_DIR}}" == "{{.ROOT_DIR2}}" ]] || [[ "{{.TASKFILE_DIR}}" == "" ]]; then echo -n "{{.ROOT_DIR2}}/hack/common"; else echo -n "{{.TASKFILE_DIR}}"; fi'
 
   VERSION:
-    sh: 'CLI="{{printf "%b" ( .IS_CLI | default false )}}" PROJECT_ROOT="{{.ROOT_DIR2}}" {{.TASKFILE_DIR2}}/get-version.sh'
+    sh: 'PROJECT_ROOT="{{.ROOT_DIR2}}" {{.TASKFILE_DIR2}}/get-version.sh'
   GIT_TREE_STATE:
     sh: 'git diff --quiet && echo "clean" || echo "dirty"'
   GIT_COMMIT:

--- a/Taskfile_library.yaml
+++ b/Taskfile_library.yaml
@@ -33,7 +33,7 @@ vars:
     sh: 'if [[ "{{.TASKFILE_DIR}}" == "{{.ROOT_DIR2}}" ]] || [[ "{{.TASKFILE_DIR}}" == "" ]]; then echo -n "{{.ROOT_DIR2}}/hack/common"; else echo -n "{{.TASKFILE_DIR}}"; fi'
 
   VERSION:
-    sh: 'PROJECT_ROOT="{{.ROOT_DIR2}}" {{.TASKFILE_DIR2}}/get-version.sh'
+    sh: 'CLI="{{printf "%b" ( .IS_CLI | default false )}}" PROJECT_ROOT="{{.ROOT_DIR2}}" {{.TASKFILE_DIR2}}/get-version.sh'
   GIT_TREE_STATE:
     sh: 'git diff --quiet && echo "clean" || echo "dirty"'
   GIT_COMMIT:
@@ -51,7 +51,10 @@ vars:
   NESTED_MODULES: '{{.NESTED_MODULES | default "" }}'
   DOCKERFILE: '{{.DOCKERFILE | default (print .TASKFILE_DIR2 "/Dockerfile") }}'
 
+  ALL_OS: [linux, darwin]
+  ALL_ARCH: [amd64, arm64]
 
+  REFERENCE_GENERATOR: '{{ .REFERENCE_GENERATOR | default (print .ROOT_DIR2 "/hack/cmdref/main.go") }}'
   LOCALBIN: '{{ env "LOCALBIN" | default ( .LOCALBIN | default (print .ROOT_DIR2 "/bin") ) }}'
   LOCALTMP: '{{ env "LOCALTMP" | default ( .LOCALTMP | default (print .ROOT_DIR2 "/tmp") ) }}'
   CONTROLLER_GEN: '{{ .CONTROLLER_GEN | default (print .LOCALBIN "/controller-gen") }}'
@@ -66,9 +69,10 @@ vars:
   # separator strings
   SEP_MSG: "This is just a separator, what did you expect to happen?"
   MAIN_SEP:    "MAIN ###########################################################################"
-  GEN_SEP:     "CODE GENERATION ### generate / gen / g #########################################"
+  GEN_SEP:     "CODE AND DOCS GENERATION ### generate / gen / g ################################"
   VAL_SEP:     "CODE VALIDATION ### validate / val / v #########################################"
   BLD_SEP:     "BUILD ARTIFACTS ### build / bld / b ############################################"
+  BIN_SEP:     "BINARY BUILDING ### bin / b ####################################################"
   BLD_BIN_SEP: "BINARY BUILD --- bin -----------------------------------------------------------"
   BLD_IMG_SEP: "IMAGE BUILD --- img ------------------------------------------------------------"
   BLD_HLM_SEP: "HELM CHART BUILD --- helm ------------------------------------------------------"
@@ -99,16 +103,18 @@ tasks:
     desc: "  Combines all code generation tasks, including formatting."
     run: once
     deps:
-    - generate:generate
+    - generate:all
   
   test:
     desc: "  Run all tests."
+    summary: This is an alias for 'validate:test'.
     run: once
     deps:
     - validate:test
   
   validate:
     desc: "  Combines all validation tasks except for tests."
+    summary: This is an alias for 'validate:all'.
     run: once
     aliases:
     - verify

--- a/generate-changelog.sh
+++ b/generate-changelog.sh
@@ -25,9 +25,6 @@ PR_COMMITS=$(echo "$GIT_LOG_OUTPUT" | grep -oE "#[0-9]+" || true | tr -d '#' | s
 PR_INFO_FILE=$(mktemp)
 echo "[" > "$PR_INFO_FILE"
 CHANGELOG_FILE=./CHANGELOG.md
-# File header Header
-echo "# Changes included in $VERSION:" > "$CHANGELOG_FILE"
-echo "" >> "$CHANGELOG_FILE"
 
 is_first=true
 for PR_NUMBER in $PR_COMMITS; do
@@ -44,6 +41,6 @@ done
 echo "]" >> "$PR_INFO_FILE"
 
 echo "Executing changelog generator for $PR_INFO_FILE ..."
-go run "$CHANGELOG_GENERATOR_SCRIPT" "$PR_INFO_FILE" >> "$CHANGELOG_FILE"
+go run "$CHANGELOG_GENERATOR_SCRIPT" "$PR_INFO_FILE" > "$CHANGELOG_FILE"
 
 cat "$CHANGELOG_FILE"

--- a/generate-docs-index.sh
+++ b/generate-docs-index.sh
@@ -38,8 +38,9 @@ function getDocName() {
     fi
   fi
   if [[ -f "$filename" ]]; then
-    local firstheader=$(grep -m1 -E '^# (.*)$' "$filename")
-    echo "${firstheader#'# '}"
+    local firstheader=$(grep -m1 -E '^##? (.*)$' "$filename")
+    firstheader=${firstheader#* }
+    echo "${firstheader#' '}"
   fi
 }
 
@@ -53,6 +54,7 @@ println
 
 (
   cd "$DOCS_FOLDER"
+  LC_COLLATE="C.UTF-8" # keep sorting consistent across different environments
   for f in *; do 
     if [[ -d "$f" ]]; then
       foldername="$(getDocFolderName "$f")"
@@ -66,6 +68,7 @@ println
 
       (
         cd "$f"
+        LC_COLLATE="C.UTF-8" # keep sorting consistent across different environments
         for f2 in *.md; do
           docname="$(getDocName "../$f" "$f2")"
           if [[ -z "$docname" ]]; then

--- a/get-version.sh
+++ b/get-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash
 
 set -euo pipefail
 source "$(realpath "$(dirname $0)/environment.sh")"

--- a/tasks_build_helm.yaml
+++ b/tasks_build_helm.yaml
@@ -47,8 +47,7 @@ tasks:
       vars:
       - COMPONENT
       - VERSION
-    status:
-    - 'test ! -f "{{.ROOT_DIR2}}/charts/{{.COMPONENT}}/Chart.yaml"'
+    if: 'test -f "{{.ROOT_DIR2}}/charts/{{.COMPONENT}}/Chart.yaml"'
     cmds:
     - '"{{.HELM}}" package "{{.ROOT_DIR2}}/charts/{{.COMPONENT}}" -d "{{.LOCALTMP}}" --version "{{.VERSION}}"'
     internal: true
@@ -83,8 +82,7 @@ tasks:
       - VERSION
       - HELM_REGISTRY
       - LOCALTMP
-    status:
-    - 'test ! -f "{{.ROOT_DIR2}}/charts/{{.COMPONENT}}/Chart.yaml"'
+    if: 'test -f "{{.ROOT_DIR2}}/charts/{{.COMPONENT}}/Chart.yaml"'
     vars:
       CHART_NAME: '{{.COMPONENT}}' # this requires the chart name to be the same as the component name
     cmds:

--- a/tasks_build_img.yaml
+++ b/tasks_build_img.yaml
@@ -96,11 +96,13 @@ tasks:
     requires:
       vars:
       - COMPONENTS
+      - ALL_ARCH
     cmds:
     - for:
         matrix:
           OS: [linux] # distroless base image only supports linux
-          ARCH: [amd64, arm64]
+          ARCH:
+            ref: .ALL_ARCH
       vars:
         OS: '{{.ITEM.OS}}'
         ARCH: '{{.ITEM.ARCH}}'
@@ -111,11 +113,13 @@ tasks:
     requires:
       vars:
       - COMPONENTS
+      - ALL_ARCH
     cmds:
     - for:
         matrix:
           OS: [linux] # distroless base image only supports linux
-          ARCH: [amd64, arm64]
+          ARCH:
+            ref: .ALL_ARCH
       vars:
         OS: '{{.ITEM.OS}}'
         ARCH: '{{.ITEM.ARCH}}'
@@ -166,11 +170,13 @@ tasks:
       vars:
       - COMPONENTS
       - VERSION
+      - ALL_ARCH
     cmds:
     - for:
         matrix:
           OS: [linux] # distroless base image only supports linux
-          ARCH: [amd64, arm64]
+          ARCH:
+            ref: .ALL_ARCH
       vars:
         OS: '{{.ITEM.OS}}'
         ARCH: '{{.ITEM.ARCH}}'
@@ -187,11 +193,13 @@ tasks:
     requires:
       vars:
       - IMG
+      - ALL_ARCH
     cmds:
     - for:
         matrix:
           OS: [linux] # distroless base image only supports linux
-          ARCH: [amd64, arm64]
+          ARCH:
+            ref: .ALL_ARCH
       cmd: 'docker manifest create {{.IMG}} --amend {{.IMG}}-{{.ITEM.OS}}-{{.ITEM.ARCH}}'
     - 'echo "Pushing image {{.IMG}}"'
     - 'docker manifest push {{.IMG}}'

--- a/tasks_cli_build.yaml
+++ b/tasks_cli_build.yaml
@@ -11,12 +11,12 @@ includes:
 tasks:
   # This is a dummy task that serves as a separator between task namespaces in the 'task -l' output.
   "---":
-    desc: "{{.BLD_BIN_SEP}}"
+    desc: "{{.BLD_SEP}}"
     cmds:
     - cmd: echo "{{.SEP_MSG}}"
       silent: true
 
-  build:
+  bin:
     desc: '  Build the binary for $OS/$ARCH.'
     summary: |
       This task builds the binary for the current operating system and architecture.
@@ -24,21 +24,20 @@ tasks:
       The binary is saved in the 'bin' folder, as $COMPONENT.$OS-$ARCH.
     requires:
       vars:
-      - COMPONENTS
+      - NAME
       - OS
       - ARCH
     deps:
     - gen:tidy
     cmds:
-    - task: gen:generate # don't use deps, since they are executed in parallel
-    - task: val:validate # and we want the code generation
-    - task: val:test # to be executed before the validation.
-    - task: build-raw
+    - task: gen:all # don't use deps, since they are executed in parallel
+    - task: val:all # and we want the code generation to be executed before the validation.
+    - task: bin-raw
       vars:
         OS: '{{.OS}}'
         ARCH: '{{.ARCH}}'
 
-  build-raw:
+  bin-raw:
     desc: "  Build the binary. Opposed to the regular build, this one just builds and skips code generation/validation tasks."
     summary: |
       This task builds the binary for the current operating system and architecture.
@@ -46,30 +45,24 @@ tasks:
       The binary is saved in the 'bin' folder, as $COMPONENT.$OS-$ARCH.
     requires:
       vars:
-      - COMPONENTS
+      - NAME
       - OS
       - ARCH
       - VERSION
-      - GIT_TREE_STATE
-      - GIT_COMMIT
-      - BUILD_DATE
       - MODULE_NAME
     cmds:
-    - for:
-        var: COMPONENTS
-        as: COMPONENT
-      cmd: 'CGO_ENABLED=0 GOOS={{.OS}} GOARCH={{.ARCH}} go build -a -ldflags="-X {{.MODULE_NAME}}/internal/version.buildVersion={{.VERSION}} -X {{.MODULE_NAME}}/internal/version.gitTreeState={{.GIT_TREE_STATE}} -X {{.MODULE_NAME}}/internal/version.gitCommit={{.GIT_COMMIT}} -X {{.MODULE_NAME}}/internal/version.buildDate={{.BUILD_DATE}}" -o {{.ROOT_DIR2}}/bin/{{.COMPONENT}}.{{.OS}}-{{.ARCH}} {{.ROOT_DIR2}}/cmd/{{.COMPONENT}}/main.go'
+    - cmd: 'CGO_ENABLED=0 GOOS={{.OS}} GOARCH={{.ARCH}} go build -a -ldflags="-X {{.MODULE_NAME}}/internal/version.buildVersion={{.VERSION}} -X {{.MODULE_NAME}}/internal/version.gitTreeState={{.GIT_TREE_STATE}} -X {{.MODULE_NAME}}/internal/version.gitCommit={{.GIT_COMMIT}} -X {{.MODULE_NAME}}/internal/version.buildDate={{.BUILD_DATE}}" -o {{.ROOT_DIR2}}/bin/{{.NAME}}.{{.OS}}-{{.ARCH}} {{.ROOT_DIR2}}'
 
-  build-multi-raw:
+  bin-multi-raw:
     desc: "  Build multi-platform binaries. Skips code generation/validation tasks."
     requires:
       vars:
-      - COMPONENTS
+      - NAME
       - ALL_OS
       - ALL_ARCH
     cmds:
     - for:
-       matrix:
+        matrix:
           OS:
             ref: .ALL_OS
           ARCH:
@@ -77,20 +70,18 @@ tasks:
       vars:
         OS: '{{.ITEM.OS}}'
         ARCH: '{{.ITEM.ARCH}}'
-      task: build-raw
+      task: bin-raw
 
   all:
     desc: "  Build multi-platform binaries."
     aliases:
-    - build-multi
+    - bin-multi
     requires:
       vars:
-      - COMPONENTS
-      - ALL_OS
-      - ALL_ARCH
+      - NAME
     cmds:
     - for:
-       matrix:
+        matrix:
           OS:
             ref: .ALL_OS
           ARCH:
@@ -98,4 +89,5 @@ tasks:
       vars:
         OS: '{{.ITEM.OS}}'
         ARCH: '{{.ITEM.ARCH}}'
-      task: build
+      task: bin
+

--- a/tasks_gen.yaml
+++ b/tasks_gen.yaml
@@ -36,7 +36,7 @@ tasks:
       cmd: '"{{.TASKFILE_DIR2}}/sed.sh" -E "s/toolchain go[0-9]+\.[0-9]+\.[0-9]+/toolchain go{{.GO_VERSION}}/" "{{.ROOT_DIR2}}/{{.MODULE}}/go.mod"' # overwrite toolchain in nested go.mod files
 
   all:
-    desc: "  Combines all code generation tasks, including formatting."
+    desc: "  Combines all code and documentation generation tasks, including formatting."
     run: once
     aliases:
     - generate
@@ -44,16 +44,17 @@ tasks:
     - task: tidy
     - task: code
     - task: manifests
+    - task: command-reference
     - task: docs
     - task: format
 
   manifests:
     desc: "  Generate manifests for CRDs."
     run: once
-    status:
-    - '[ "{{.API_DIRS | default ""}}" == "" ] || [ "{{.MANIFEST_OUT | default ""}}" == "" ]'
+    if: '{{ and ( not ( .IS_CLI | default false ) ) ( or ( ne ( .API_DIRS | default "" ) "" ) ( ne ( .MANIFEST_OUT | default "" ) "" ) ) }}'
     cmds:
     - task: manifests-internal
+    # internal: '{{ .IS_CLI | default false }}' # hide this task for CLI repos (https://github.com/go-task/task/issues/2769)
 
   manifests-internal:
     desc: "  Generate manifests for CRDs."
@@ -74,10 +75,10 @@ tasks:
   code:
     desc: "  Generate code (mainly DeepCopy functions) for all modules."
     run: once
-    status:
-    - '[ "{{.API_DIRS | default ""}}" == "" ]'
+    if: '{{ and ( not ( .IS_CLI | default false ) ) ( ne ( .API_DIRS | default "" ) "" ) }}'
     cmds:
     - task: code-internal
+    # internal: '{{ .IS_CLI | default false }}' # hide this task for CLI repos (https://github.com/go-task/task/issues/2769)
 
   code-internal:
     desc: "  Generate code (mainly DeepCopy functions) for all modules."
@@ -96,8 +97,7 @@ tasks:
   docs:
     desc: "  Generate the documentation index for the project. No effect, unless GENERATE_DOCS_INDEX is set to 'true' in the Taskfile."
     run: once
-    status:
-    - '[ "{{.GENERATE_DOCS_INDEX | default "false"}}" == "false" ]'
+    if: '{{ ne ( .GENERATE_DOCS_INDEX | default "false" ) "false" }}'
     cmds:
     - task: docs-internal
 
@@ -146,7 +146,7 @@ tasks:
       code_dirs:
         sh: '{{.TASKFILE_DIR2}}/unfold.sh --clean --no-unfold --inline {{.CODE_DIRS}}' # goimports doesn't like the '/...' syntax
     cmds:
-    - '{{.FORMATTER}} -l -w -local={{.MODULE_NAME}} {{.code_dirs}}'
+    - '{{.FORMATTER}} -l -w -local={{.MODULE_NAME}} {{if ( .IS_CLI | default false )}}"{{.ROOT_DIR2}}/main.go"{{end}} {{.code_dirs}}'
 
   format:
     desc: "  Combines all formatting tasks."
@@ -154,3 +154,19 @@ tasks:
     cmds:
     - task: fmt
     - task: format-imports
+
+  command-reference:
+    desc: "  Generate the command reference documentation. CLI only."
+    aliases:
+    - cmdref
+    run: once
+    requires:
+      vars:
+      - REFERENCE_GENERATOR
+    vars:
+      REFERENCE_GENERATOR: '{{ .REFERENCE_GENERATOR }}'
+    if: '{{ and ( .IS_CLI | default false ) ( ne .REFERENCE_GENERATOR "" ) }}'
+    cmds:
+    - 'rm -f "{{.ROOT_DIR2}}/docs/reference/"*.md'
+    - 'go run "{{.REFERENCE_GENERATOR}}" "{{.ROOT_DIR2}}/docs/reference"'
+    # internal: '{{ not ( .IS_CLI | default false ) }}' # hide this task for non-CLI repos (https://github.com/go-task/task/issues/2769)

--- a/tasks_rls.yaml
+++ b/tasks_rls.yaml
@@ -1,5 +1,10 @@
 version: 3
 
+includes:
+  clibuild:
+    taskfile: tasks_cli_build.yaml
+    internal: true
+
 tasks:
   # This is a dummy task that serves as a separator between task namespaces in the 'task -l' output.
   "---":
@@ -50,12 +55,25 @@ tasks:
     vars:
       changes:
         sh: '( cd "{{.ROOT_DIR2}}"; git status --short )'
-    status:
-    - 'test -z "$( cd "{{.ROOT_DIR2}}" && git status --porcelain=v1)"'
+    if: 'test -n "$( cd "{{.ROOT_DIR2}}" && git status --porcelain=v1)"'
     prompt:
     - 'There are uncommitted changes in the working directory:{{"\n"}}{{.changes}}{{"\n\n"}}These changes will be included in the release commit, unless you stash, commit, or remove them otherwise before. Do you want to continue?'
     internal: true
-  
+
+  prepare-dev-cycle:
+    desc: "  Prepares the repository for further development after a release. Creates a commit that adds a '-dev' suffix to the version. Meant to be run after a release commit has been pushed to the main branch."
+    run: once
+    requires:
+      vars:
+      - VERSION
+      - MODULE_NAME
+      - NESTED_MODULES
+    cmds:
+    - task: set-version
+      vars:
+        CLI_ARGS: '{{.VERSION}}-dev'
+    - '( cd "{{.ROOT_DIR2}}"; git add VERSION go.mod; git commit -m "chore(release): prepare for next development iteration (version {{.VERSION}}-dev)" )'
+
   release-internal:
     desc: "  Prepares a new release by creating a commit that will result in a release when pushed."
     run: once
@@ -96,13 +114,15 @@ tasks:
       VERSION: '{{.CLI_ARGS | splitList " " | first}}'
     cmds:
     - 'echo -n "{{.VERSION}}" > "{{.ROOT_DIR2}}/VERSION"'
-    - for:
+    - if: '[[ ! "{{.VERSION}}" =~ .*-dev(-[0-9a-f]*)? ]]' # only set chart versions for release versions (without '-dev' suffix)
+      for:
         var: COMPONENTS
       vars:
         COMPONENT: '{{.ITEM}}'
         VERSION: '{{.VERSION}}'
       task: set-chart-version-internal
-    - for:
+    - if: '[[ ! "{{.VERSION}}" =~ .*-dev(-[0-9a-f]*)? ]]' # only set nested module versions for release versions (without '-dev' suffix)
+      for:
         var: NESTED_MODULES
       vars:
         MODULE: '{{.ITEM}}'
@@ -117,6 +137,7 @@ tasks:
       vars:
       - VERSION
       - COMPONENT
+    if: '{{ not ( .IS_CLI | default false ) }}' # skip this task for CLI repos, since they don't have charts
     cmds:
     - '{{.TASKFILE_DIR2}}/sed.sh -E "s@version: v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*@version: {{.VERSION}}@1" "{{.ROOT_DIR2}}/charts/{{.COMPONENT}}/Chart.yaml"'
     - '{{.TASKFILE_DIR2}}/sed.sh -E "s@appVersion: v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*@appVersion: {{.VERSION}}@1" "{{.ROOT_DIR2}}/charts/{{.COMPONENT}}/Chart.yaml"'
@@ -169,3 +190,27 @@ tasks:
       - VERSION
     cmds:
     -  'VERSION={{.VERSION}} {{.TASKFILE_DIR2}}/generate-changelog.sh'
+
+  artifacts:
+    desc: "  Creates the artifacts to be attached to a github release. Basically tar archives of the built binaries for each platform. Outputs them to bin/release. CLI only."
+    run: once
+    requires:
+      vars:
+      - NAME
+      - VERSION
+      - ALL_OS
+      - ALL_ARCH
+    vars:
+      VERSION_NO_PREFIX: '{{regexReplaceAll "^[vV]" .VERSION ""}}'
+    if: '{{ .IS_CLI | default false }}' # only run this task for CLI repos
+    deps:
+    - clibuild:bin-multi-raw
+    cmds:
+    - 'rm -rf {{.ROOT_DIR2}}/bin/release && mkdir -p {{.ROOT_DIR2}}/bin/release'
+    - for:
+        matrix:
+          OS:
+            ref: .ALL_OS
+          ARCH:
+            ref: .ALL_ARCH
+      cmd: 'rm -f "{{.ROOT_DIR2}}/bin/{{.NAME}}" && mv "{{.ROOT_DIR2}}/bin/{{.NAME}}.{{.ITEM.OS}}-{{.ITEM.ARCH}}" "{{.ROOT_DIR2}}/bin/{{.NAME}}" && tar -czf "{{.ROOT_DIR2}}/bin/release/{{.NAME}}-{{.VERSION_NO_PREFIX}}-{{.ITEM.OS}}-{{.ITEM.ARCH}}.tar.gz" -C "{{.ROOT_DIR2}}/bin" {{.NAME}}'

--- a/tasks_val.yaml
+++ b/tasks_val.yaml
@@ -36,8 +36,7 @@ tasks:
   test-envtest-dep:
     desc: "  Install the envtest dependency, if marked as required."
     run: once
-    status:
-    - '[ "{{.ENVTEST_REQUIRED | default "false"}}" != "true" ]'
+    if: '{{ eq ( .ENVTEST_REQUIRED | default "false") "true" }}'
     cmds:
     - task: tools:envtest
     internal: true
@@ -57,8 +56,7 @@ tasks:
   docs:
     desc: "  Checks if the documentation index is up-to-date."
     run: once
-    status:
-    - '[ "{{.GENERATE_DOCS_INDEX | default "false"}}" == "false" ]'
+    if: '{{ eq ( .GENERATE_DOCS_INDEX | default "false") "true" }}'
     cmds:
     - task: docs-internal
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This repository contains very useful workflow definitions that we use in all of our repositories. However, it was designed for k8s controllers and is not suitable for CLI tools, which have slightly different requirements - e.g. no docker image or helm chart is required, but the binaries should be attached to the release and/or made available via homebrew.

This PR expands the capabilities of this submodule so that it can also be used for repositories containing CLI tools. It tries to avoid breaking changes, so all the controller repositories that currently use this submodule should be able to continue doing so without any changes. Unfortunately, some aspects are hard to test (e.g. the github actions related to creation of new releases), so there is the possibility for things that I overlooked.

Why do we need this? 
We are planning to create some CLI tools ourselves in the somewhat near future, e.g. for https://github.com/openmcp-project/backlog/issues/234, and it would be very helpful if we could simply reuse our existing task definitions and code checks and so on.

List of changes (copied from the release notes below, since I noticed that we don't do releases for this repo and it is just harder to read below):
- The 'build' submodule now also supports CLI repositories. See the [documentation](./README.md#cli-variant) for further details.
- For the CLI variant, it is possible to have the binaries made available via a custom homebrew tap with the new homebrew releaser github action. See the [documentation](./README.md#homebrew-workflow) for further details.
- For the CLI variant, tarballed binaries can now be attached to github releases. This feature is automatically activated by setting the `is_cli` value to `true` for the release workflow.
- App ID and private key have been made configurable for the github workflows, enabling them to be used from outside this org. The previous values are kept as defaults to avoid breaking changes.
- `task generate` now works as intended and runs _all_ generation tasks. Basically, it is now an alias for `task generate:all`, while it wrongfully aliased `task generate:generate` before.
- The taskfiles have been cleaned up and improved. This also includes usage of the new `if` feature to conditionally skip some tasks, for which previously some hacky workarounds have been used. The feature was introduced with version [v3.47.0](https://github.com/go-task/task/releases/tag/v3.47.0), so you might need to upgrade your local `task` version.
- Removed a duplicate 'CHANGELOG' header from the generated release notes.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

I initially [forked](https://github.com/Diaphteiros/cli-build) this repo to use it for my kubeswitcher tooling. However, the fork is not suitable for k8s controllers anymore and can only handle CLI tools, so I tried to bring the changes from the fork into this repo while avoiding breaking changes.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The 'build' submodule now also supports CLI repositories. See the [documentation](./README.md#cli-variant) for further details.
```
```feature developer
For the CLI variant, it is possible to have the binaries made available via a custom homebrew tap with the new homebrew releaser github action. See the [documentation](./README.md#homebrew-workflow) for further details.
```
```feature developer
For the CLI variant, tarballed binaries can now be attached to github releases. This feature is automatically activated by setting the `is_cli` value to `true` for the release workflow.
```
```feature developer
App ID and private key have been made configurable for the github workflows, enabling them to be used from outside this org. The previous values are kept as defaults to avoid breaking changes.
```
```breaking developer
`task generate` now works as intended and runs _all_ generation tasks. Basically, it is now an alias for `task generate:all`, while it wrongfully aliased `task generate:generate` before.
```
```breaking developer
The taskfiles have been cleaned up and improved. This also includes usage of the new `if` feature to conditionally skip some tasks, for which previously some hacky workarounds have been used. The feature was introduced with version [v3.47.0](https://github.com/go-task/task/releases/tag/v3.47.0), so you might need to upgrade your local `task` version.
```
```bugfix developer
Removed a duplicate 'CHANGELOG' header from the generated release notes.
```

