### PR TITLE
fix: use github-actions bot identity for release commits

### DIFF
--- a/.github/workflows/release.lib.yaml
+++ b/.github/workflows/release.lib.yaml
@@ -84,19 +84,14 @@ jobs:
           fi
           echo "Tag ${{ env.version }} doesn't exists. Proceeding with release."
 
+      - name: Configure Git for GitHub Actions
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Create Git tag
         if: ${{ env.SKIP != 'true' }}
         run: |
-          AUTHOR_NAME=$(git log -1 --pretty=format:'%an')
-          AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
-          echo "Tagging as $AUTHOR_NAME <$AUTHOR_EMAIL>"
-
-          echo "AUTHOR_NAME=$AUTHOR_NAME" >> $GITHUB_ENV
-          echo "AUTHOR_EMAIL=$AUTHOR_EMAIL" >> $GITHUB_ENV
-
-          git config user.name "$AUTHOR_NAME"
-          git config user.email "$AUTHOR_EMAIL"
-
           git tag -a "${{ env.version }}" -m "Release ${{ env.version }}"
           git push origin "${{ env.version }}"
 
@@ -134,7 +129,5 @@ jobs:
       - name: Push dev VERSION
         if: ${{ env.SKIP != 'true' }}
         run: |
-          git config user.name "${{ env.AUTHOR_NAME }}"
-          git config user.email "${{ env.AUTHOR_EMAIL }}"
           task r:prepare-dev-cycle --verbose
           git push origin main


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces human user credential extraction with explicit `github-actions[bot]` identity for git operations in the release workflow. This ensures automated release commits (like the dev version bump) are clearly attributed to CI rather than impersonating the human user who triggered the release.

This is consistent with the approach used in `renovate-generate.lib.yaml`.

**Which issue(s) this PR fixes**:
Fixes #145

**Special notes for your reviewer**:
- Removed extraction of `AUTHOR_NAME` and `AUTHOR_EMAIL` from git history
- Removed per-step git config that used human credentials
- Added a single "Configure Git for GitHub Actions" step that sets the bot identity once
- All git tag and commit operations now use `github-actions[bot]`

**Release note**:
```bugfix operator
Release workflow now correctly attributes automated commits to github-actions[bot] instead of impersonating human users.
```