### PR TITLE
feat: Add several local development helper tasks

### DIFF
--- a/tasks_build_bin.yaml
+++ b/tasks_build_bin.yaml
@@ -99,3 +99,67 @@ tasks:
         OS: '{{.ITEM.OS}}'
         ARCH: '{{.ITEM.ARCH}}'
       task: build
+
+  platform-cluster-check:
+    desc: "  Verify that that the operator is running against the platform cluster."
+    internal: true
+    requires:
+      vars:
+      - POD_NAMESPACE
+    cmds:
+    - cmd: |
+        {{if .KUBECONFIG}}KUBECONFIG="{{.KUBECONFIG}}" {{end}}kubectl get namespace "{{.POD_NAMESPACE}}" >/dev/null 2>&1 || \
+          { echo "Error: namespace '{{.POD_NAMESPACE}}' not found on the current cluster. Are you pointing at the platform cluster?"; exit 1; }
+
+  run-local-init:
+    desc: "  Run 'init' subcommand to install CRDs on the platform cluster."
+    summary: |
+      Runs the 'init' subcommand of the operator against the platform cluster.
+      Must be run before 'run-local' and re-run whenever CRD definitions change.
+      Set 'PROVIDER_NAME' to override the name of the ServiceProvider resource (defaults to COMPONENTS).
+      Optionally set 'KUBECONFIG' to the path of the platform cluster kubeconfig.
+      DEV_DEBUG=true is set automatically so the controller uses locally-reachable cluster addresses.
+    requires:
+      vars:
+      - COMPONENTS
+    vars:
+      PROVIDER_NAME: '{{.PROVIDER_NAME | default .COMPONENTS}}'
+    deps:
+    - task: platform-cluster-check
+      vars:
+        POD_NAMESPACE: '{{.POD_NAMESPACE | default "openmcp-system"}}'
+        KUBECONFIG: '{{.KUBECONFIG}}'
+    cmds:
+    - cmd: |
+        {{if .KUBECONFIG}}KUBECONFIG="{{.KUBECONFIG}}" {{end}}POD_NAMESPACE="{{.POD_NAMESPACE | default "openmcp-system"}}" DEV_DEBUG=true \
+        go run "{{.ROOT_DIR2}}/cmd/{{.COMPONENTS}}/main.go" init \
+          --environment "{{.ENVIRONMENT | default "local"}}" \
+          --provider-name "{{.PROVIDER_NAME}}" \
+          --verbosity "{{.VERBOSITY | default "DEBUG"}}"
+
+  run-local:
+    desc: "  Run the controller against a KinD cluster (requires run-local-init first)."
+    summary: |
+      Runs the operator against the platform cluster.
+      Set 'PROVIDER_NAME' to the name of the ServiceProvider resource.
+      Optionally set 'KUBECONFIG' to the path of the platform cluster kubeconfig.
+      DEV_DEBUG=true is set automatically so the controller uses locally-reachable
+      cluster addresses instead of in-cluster API server addresses.
+    interactive: true
+    requires:
+      vars:
+      - COMPONENTS
+    vars:
+      PROVIDER_NAME: '{{.PROVIDER_NAME | default .COMPONENTS}}'
+    deps:
+    - task: platform-cluster-check
+      vars:
+        POD_NAMESPACE: '{{.POD_NAMESPACE | default "openmcp-system"}}'
+        KUBECONFIG: '{{.KUBECONFIG}}'
+    cmds:
+    - cmd: |
+        {{if .KUBECONFIG}}KUBECONFIG="{{.KUBECONFIG}}" {{end}}POD_NAMESPACE="{{.POD_NAMESPACE | default "openmcp-system"}}" DEV_DEBUG=true \
+        go run "{{.ROOT_DIR2}}/cmd/{{.COMPONENTS}}/main.go" run \
+          --environment "{{.ENVIRONMENT | default "local"}}" \
+          --provider-name "{{.PROVIDER_NAME}}" \
+          --verbosity "{{.VERBOSITY | default "DEBUG"}}"

--- a/tasks_build_img.yaml
+++ b/tasks_build_img.yaml
@@ -29,6 +29,22 @@ tasks:
     - '( docker buildx ls | grep "{{.DOCKER_BUILDER_NAME}}" >/dev/null ) || docker buildx create --name {{.DOCKER_BUILDER_NAME}} >/dev/null' # duplicate the check because this might throw an error if run with '-f' otherwise
     internal: true
 
+  print-image:
+    desc: "  Print the built image name(s)."
+    requires:
+      vars:
+      - COMPONENTS
+      - VERSION
+      - OS
+      - ARCH
+    vars:
+      IMAGE_BASE:
+        sh: 'PROJECT_ROOT="{{.ROOT_DIR2}}" {{.TASKFILE_DIR2}}/get-registry.sh --image'
+    cmds:
+    - for:
+        var: COMPONENTS
+      cmd: 'echo "Built image: {{.IMAGE_BASE}}/{{.ITEM}}:{{.VERSION}}-{{.OS}}-{{.ARCH}}"'
+
   build:
     desc: "  Build the image for $IMAGE_OS/$ARCH."
     summary: |
@@ -71,6 +87,31 @@ tasks:
         OS: '{{.IMAGE_OS}}'
         ARCH: '{{.ARCH}}'
       task: build-internal
+
+  load-local:
+    desc: "  Load built image(s) into a KinD cluster."
+    summary: |
+      Loads the built images into a KinD cluster.
+      Set 'KIND_CLUSTER_NAME' to specify the cluster (default: 'platform').
+    requires:
+      vars:
+      - COMPONENTS
+      - VERSION
+    vars:
+      IMAGE_BASE:
+        sh: 'PROJECT_ROOT="{{.ROOT_DIR2}}" {{.TASKFILE_DIR2}}/get-registry.sh --image'
+      KIND_CLUSTER_NAME: '{{.KIND_CLUSTER_NAME | default "platform"}}'
+    cmds:
+    - for:
+        var: COMPONENTS
+      cmd: |
+        if [[ "$(go env GOOS)" == "darwin" ]]; then
+          echo "Loading {{.IMAGE_BASE}}/{{.ITEM}}:{{.VERSION}}-{{.IMAGE_OS}}-{{.ARCH}} into KinD cluster {{.KIND_CLUSTER_NAME}} (macOS mode)..."
+          docker save --platform="linux/{{.ARCH}}" "{{.IMAGE_BASE}}/{{.ITEM}}:{{.VERSION}}-{{.IMAGE_OS}}-{{.ARCH}}" | kind load image-archive --name "{{.KIND_CLUSTER_NAME}}" /dev/stdin
+        else
+          echo "Loading {{.IMAGE_BASE}}/{{.ITEM}}:{{.VERSION}}-{{.IMAGE_OS}}-{{.ARCH}} into KinD cluster {{.KIND_CLUSTER_NAME}}..."
+          kind load docker-image --name "{{.KIND_CLUSTER_NAME}}" "{{.IMAGE_BASE}}/{{.ITEM}}:{{.VERSION}}-{{.IMAGE_OS}}-{{.ARCH}}"
+        fi
 
   build-internal:
     desc: "  Build the image for a single component. Requires the docker builder to have been prepared before."


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds local development tasks to streamline the inner dev loop for service provider and controller repos:
tasks_build_img.yaml:
- print-image: prints the local image name.
- load-local: loads built images into a KinD cluster (with macOS/Linux handling)

tasks_build_bin.yaml:
- platform-cluster-check: makes sure local commands are are against the platform cluster.
- run-local-init: runs the init subcommand locally to install CRDs on the platform cluster.
- run-local — runs the controller locally against the platform cluster.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`COMPONENTS` in plural form is used a bit "loosely" here as it's almost always indicates a singular. But refactoring this is a big job and will require changes to all repos that uses this repo. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add local development tasks to improve local development workflow. 
```
