### PR TITLE
fix(task): rebuild golangci-lint when Go toolchain changes

### DIFF
--- a/tasks_tools.yaml
+++ b/tasks_tools.yaml
@@ -79,8 +79,9 @@ tasks:
     status:
     - test -x {{.LINTER}}
     - '{{.LINTER}} --version | grep -q {{.LINTER_VERSION | trimPrefix "v"}}'
+    - '{{.LINTER}} --version | grep -q "$(go env GOVERSION)"'
     cmds:
-    - 'curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b {{.LOCALBIN}} {{.LINTER_VERSION}}'
+    - 'GOBIN="{{.LOCALBIN}}" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@{{.LINTER_VERSION}}'
     internal: true
 
   jq:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR hardens local tool installation checks to avoid false “up to date” results that caused flaky build/lint behavior across environments.

Specifically, it updates the golangci-lint task to:
- verify not only the pinned linter version, but also that the binary was built with the currently active Go toolchain (go env GOVERSION) 
- install golangci-lint via go install so the binary is compiled for the current environment/toolchain. Without this, stale binaries (for a different Go version or environment) could pass status checks and then fail later during linting with Go version mismatch errors.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
