### PR TITLE
fix: crd generation with embedded metadata

### DIFF
--- a/tasks_gen.yaml
+++ b/tasks_gen.yaml
@@ -69,7 +69,7 @@ tasks:
     - cmd: rm -rf {{.MANIFEST_OUT}}
     - for:
         var: API_DIRS
-      cmd: '{{.CONTROLLER_GEN}} crd:allowDangerousTypes=true paths={{.ITEM}} output:crd:artifacts:config={{.MANIFEST_OUT}}'
+      cmd: '{{.CONTROLLER_GEN}} crd:allowDangerousTypes=true,generateEmbeddedObjectMeta=true paths={{.ITEM}} output:crd:artifacts:config={{.MANIFEST_OUT}}'
     internal: true
 
   code:


### PR DESCRIPTION
**What this PR does / why we need it**:
The CRD generation seemingly contains some special logic for the k8s standard `ObjectMeta` struct, see https://github.com/kubernetes-sigs/controller-tools/pull/539. This leads to embedded metadata fields - as we have in the [shootTemplate](https://github.com/openmcp-project/cluster-provider-gardener/blob/v0.12.1/api/core/v1alpha1/providerconfiguration_types.go#L25-L26) field, which uses the type from [here](https://github.com/gardener/gardener/blob/v1.145.0/pkg/apis/core/v1beta1/types_shoot.go#L53-L62), for example - being rendered as just `type: object`, without any schema, in the generated CRDs, see [here](https://github.com/openmcp-project/cluster-provider-gardener/blob/v0.12.1/api/crds/manifests/gardener.clusters.openmcp.cloud_providerconfigs.yaml#L117-L119).
As k8s by default prunes unknown fields, this leads to metadata fields, such as annotations and labels, not being propagated to the `Shoot` resources, because they disappear as soon as the `ProviderConfig` resource is pushed into the cluster. A patch to the CRD resource is required to make this work, which is cumbersome and undesirable.

This PR fixes that problem by setting a flag on the CRD generation which causes most of the metadata fields to be rendered into the CRD schema. Some, e.g. `ownerReferences` are still missing for some reason, but the important ones in our case - annotations and labels - are there.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Added `generateEmbeddedObjectMeta=true` to the CRD generator's flags. This should embedded `ObjectMeta` fields have their schema correctly generated into the respective CRDs. The missing schema was causing problems, e.g. in the `spec.shootTemplate` field of the Gardener ClusterProvider's `ProviderConfig` resource.
```
