### PR TITLE
fix: explicitly set homebrew version to release tag

### DIFF
--- a/.github/workflows/homebrew.lib.yaml
+++ b/.github/workflows/homebrew.lib.yaml
@@ -42,6 +42,8 @@ jobs:
 
           github_token: ${{ secrets.token }}
 
+          version: "${{ github.event.release.tag_name }}"
+
           # This expects the binary contained in the release artifact tarball to be named as the repository.
           install: |
             bin.install "${{ inputs.binary }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed a bug in the homebrew release flow which could cause homebrew to detect the wrong version for a formula. This would result in always the same version being recognized, leading to brew never updating the respective tool.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
