### PR TITLE
fix: envtest handling

### DIFF
--- a/tasks_tools.yaml
+++ b/tasks_tools.yaml
@@ -179,8 +179,8 @@ tasks:
     deps:
     - localbin
     vars:
-      ENVTEST_VERSION: '{{ env "ENVTEST_VERSION" | default ( .ENVTEST_VERSION | default "release-0.23" ) }}'
-      ENVTEST_K8S_VERSION: '{{ env "ENVTEST_K8S_VERSION" | default ( .ENVTEST_K8S_VERSION | default "1.30.0" ) }}'
+      ENVTEST_VERSION: '{{ env "ENVTEST_VERSION" | default ( .ENVTEST_VERSION | default "release-0.24" ) }}'
+      ENVTEST_K8S_VERSION: '{{ env "ENVTEST_K8S_VERSION" | default ( .ENVTEST_K8S_VERSION | default "1.36.0" ) }}'
     status:
     - 'test -x "{{.ENVTEST}}"'
     - test -f {{.LOCALBIN}}/envtest_version

--- a/tasks_val.yaml
+++ b/tasks_val.yaml
@@ -24,7 +24,7 @@ tasks:
     desc: "  Run all tests."
     run: once
     vars:
-      ENVTEST_K8S_VERSION: '{{ env "ENVTEST_K8S_VERSION" | default ( .ENVTEST_K8S_VERSION | default "1.30.0" ) }}'
+      ENVTEST_REQUIRED: 'true'
     requires:
       vars:
       - CODE_DIRS


### PR DESCRIPTION
**What this PR does / why we need it**:
- Set `ENVTEST_K8S_VERSION` only once in `task_val.yaml`
- Update envtest version
- Install envtest when running task test with Task_library.yaml. This was not the case, before. Following, the tests did not work on a new machine.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```chore|dependency
Update envtest versions and require envtest for task:test in Task_library.yaml
```
