### PR TITLE
feat: enable FIPS-140 compliant build and base image

### DIFF
--- a/.github/workflows/publish.lib.yaml
+++ b/.github/workflows/publish.lib.yaml
@@ -94,6 +94,10 @@ jobs:
         run: |
           task build:img:all --verbose
 
+      - name: Verify FIPS compliance
+        run: |
+          task build:img:verify-fips --verbose
+
       - name: Package and Push Helm Charts
         run: |
           task build:helm:all --verbose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-# Use distroless as minimal base image to package the component binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
+# Minimal FIPS-compliant runtime image.
+# The binary must have been built with Dockerfile.fips-builder beforehand.
+# At runtime the binary dlopens gardenlinux's FIPS 140-validated OpenSSL,
+# which is pre-configured as the default crypto provider in this image.
+FROM ghcr.io/gardenlinux/gardenlinux-fips:1877.19
 ARG TARGETOS
 ARG TARGETARCH
 ARG COMPONENT
 WORKDIR /
-COPY bin/$COMPONENT.$TARGETOS-$TARGETARCH /<component>
+COPY bin/$COMPONENT.$TARGETOS-fips-$TARGETARCH /<component>
 USER 65532:65532
 
-# docker doesn't substitue args in ENTRYPOINT, so we replace this during the build script
+# docker doesn't substitute args in ENTRYPOINT, so we replace this during the build script
 ENTRYPOINT ["/<component>"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # The binary must have been built with Dockerfile.fips-builder beforehand.
 # At runtime the binary dlopens gardenlinux's FIPS 140-validated OpenSSL,
 # which is pre-configured as the default crypto provider in this image.
-FROM ghcr.io/gardenlinux/gardenlinux-fips:1877.19
+FROM ghcr.io/gardenlinux/gardenlinux/fips:1877.23
 ARG TARGETOS
 ARG TARGETARCH
 ARG COMPONENT

--- a/Dockerfile.fips-builder
+++ b/Dockerfile.fips-builder
@@ -71,7 +71,8 @@ RUN set -eux; \
         -ldflags="-X ${MODULE_NAME}/internal/version.buildVersion=${VERSION} \
                   -X ${MODULE_NAME}/internal/version.gitTreeState=${GIT_TREE_STATE} \
                   -X ${MODULE_NAME}/internal/version.gitCommit=${GIT_COMMIT} \
-                  -X ${MODULE_NAME}/internal/version.buildDate=${BUILD_DATE}" \
+                  -X ${MODULE_NAME}/internal/version.buildDate=${BUILD_DATE} \
+                  -X github.com/openmcp-project/controller-utils/pkg/fips.fipsEnforced=true" \
         -o /out/${COMPONENT}.${TARGETOS}-fips-${TARGETARCH} ./cmd/${COMPONENT}/main.go
 
 # Export stage — only the compiled binary is written to the output directory.

--- a/Dockerfile.fips-builder
+++ b/Dockerfile.fips-builder
@@ -1,0 +1,84 @@
+# Builds a FIPS-compliant binary using Microsoft Go with GOEXPERIMENT=systemcrypto.
+# The resulting binary routes all crypto/* calls to the system OpenSSL via dlopen
+# at runtime, which on gardenlinux-fips resolves to the FIPS 140-validated OpenSSL.
+#
+# Usage (via `docker buildx build --output`):
+#   docker buildx build \
+#     --platform linux/<ARCH> \
+#     --build-arg BUILDARCH=<host-arch> \
+#     --build-arg TARGETOS=linux \
+#     --build-arg TARGETARCH=<ARCH> \
+#     --build-arg COMPONENT=<name> \
+#     --build-arg VERSION=... \
+#     --build-arg GIT_TREE_STATE=... \
+#     --build-arg GIT_COMMIT=... \
+#     --build-arg BUILD_DATE=... \
+#     --build-arg MODULE_NAME=... \
+#     --output type=local,dest=bin/ \
+#     -f Dockerfile.fips-builder .
+#
+# The binary is written to bin/<COMPONENT>.linux-fips-<ARCH> on the host.
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26-bookworm
+ARG BUILDARCH
+ARG TARGETOS
+ARG TARGETARCH
+
+# Install cross-compiler + target-arch OpenSSL headers.
+# This layer is cached as long as BUILDARCH and TARGETARCH don't change,
+# so the expensive apt install only re-runs when the target architecture changes.
+RUN set -eux; \
+    if [ "$BUILDARCH" = "$TARGETARCH" ]; then \
+        apt-get update && apt-get install -y --no-install-recommends gcc libssl-dev; \
+    else \
+        dpkg --add-architecture "$TARGETARCH" && apt-get update; \
+        case "$TARGETARCH" in \
+            amd64) apt-get install -y --no-install-recommends gcc-x86-64-linux-gnu libc6-dev-amd64-cross libssl-dev:amd64 ;; \
+            arm64) apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross libssl-dev:arm64 ;; \
+            *) echo "Unsupported TARGETARCH: $TARGETARCH"; exit 1 ;; \
+        esac; \
+    fi; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+ARG COMPONENT
+ARG VERSION
+ARG GIT_TREE_STATE
+ARG GIT_COMMIT
+ARG BUILD_DATE
+ARG MODULE_NAME
+WORKDIR /workspace
+COPY . .
+
+# Build the binary. CC must be inline — shell variables don't persist across RUN layers.
+# GOENV=off prevents any persisted Go env file from leaking a stale GOOS=darwin value,
+# which would cause the Go toolchain to inject macOS-style -arch flags into the gcc
+# cross-compiler invocation (see golang/go#74410).
+RUN set -eux; \
+    case "$BUILDARCH-$TARGETARCH" in \
+        amd64-amd64|arm64-arm64) CC=gcc ;; \
+        *-amd64) CC=x86_64-linux-gnu-gcc ;; \
+        *-arm64) CC=aarch64-linux-gnu-gcc ;; \
+        *) echo "Unsupported BUILDARCH-TARGETARCH: $BUILDARCH-$TARGETARCH"; exit 1 ;; \
+    esac; \
+    case "$TARGETARCH" in \
+        amd64) PKG=/usr/lib/x86_64-linux-gnu/pkgconfig ;; \
+        arm64) PKG=/usr/lib/aarch64-linux-gnu/pkgconfig ;; \
+    esac; \
+    CC="$CC" PKG_CONFIG_PATH="$PKG" \
+    GOENV=off \
+    CGO_ENABLED=1 GOEXPERIMENT=systemcrypto \
+    CGO_CFLAGS="" CGO_LDFLAGS="" \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a \
+        -ldflags="-X ${MODULE_NAME}/internal/version.buildVersion=${VERSION} \
+                  -X ${MODULE_NAME}/internal/version.gitTreeState=${GIT_TREE_STATE} \
+                  -X ${MODULE_NAME}/internal/version.gitCommit=${GIT_COMMIT} \
+                  -X ${MODULE_NAME}/internal/version.buildDate=${BUILD_DATE}" \
+        -o /out/${COMPONENT}.${TARGETOS}-fips-${TARGETARCH} ./cmd/${COMPONENT}/main.go
+
+# Export stage — only the compiled binary is written to the output directory.
+# This ensures `--output type=local,dest=bin/` on the host receives only the
+# binary, not the full build context or Go module cache.
+FROM scratch AS export
+ARG COMPONENT
+ARG TARGETOS
+ARG TARGETARCH
+COPY --from=0 /out/${COMPONENT}.${TARGETOS}-fips-${TARGETARCH} .

--- a/Taskfile_library.yaml
+++ b/Taskfile_library.yaml
@@ -50,6 +50,7 @@ vars:
     sh: 'cat "{{.ROOT_DIR2}}/go.mod" | grep "module " | sed "s/module //" | sed -E "s/[[:blank:]].*//"'
   NESTED_MODULES: '{{.NESTED_MODULES | default "" }}'
   DOCKERFILE: '{{.DOCKERFILE | default (print .TASKFILE_DIR2 "/Dockerfile") }}'
+  DOCKERFILE_FIPS_BUILDER: '{{.DOCKERFILE_FIPS_BUILDER | default (print .TASKFILE_DIR2 "/Dockerfile.fips-builder") }}'
 
   ALL_OS: [linux, darwin]
   ALL_ARCH: [amd64, arm64]

--- a/tasks_build_bin.yaml
+++ b/tasks_build_bin.yaml
@@ -99,3 +99,101 @@ tasks:
         OS: '{{.ITEM.OS}}'
         ARCH: '{{.ITEM.ARCH}}'
       task: build
+
+  build-fips:
+    desc: '  Build FIPS-compliant binary for $OS/$ARCH using Microsoft Go + GOEXPERIMENT=systemcrypto.'
+    summary: |
+      Builds a FIPS-compliant binary using the Microsoft Go toolchain inside Docker.
+      The binary is compiled with GOEXPERIMENT=systemcrypto so that all crypto/* calls
+      are routed through the system OpenSSL (gardenlinux-fips) via dlopen at runtime.
+      Cross-compilation is fully handled inside the Docker builder image — no special
+      host toolchain required beyond Docker.
+      The binary is saved in the 'bin' folder, as $COMPONENT.$OS-$ARCH.
+    requires:
+      vars:
+      - COMPONENTS
+      - OS
+      - ARCH
+    deps:
+    - gen:tidy
+    cmds:
+    - task: gen:generate
+    - task: val:validate
+    - task: val:test
+    - task: build-fips-raw
+      vars:
+        OS: '{{.OS}}'
+        ARCH: '{{.ARCH}}'
+
+  build-fips-raw:
+    desc: "  Build FIPS-compliant binary. Skips code generation/validation tasks."
+    requires:
+      vars:
+      - COMPONENTS
+      - OS
+      - ARCH
+      - VERSION
+      - GIT_TREE_STATE
+      - GIT_COMMIT
+      - BUILD_DATE
+      - MODULE_NAME
+      - DOCKERFILE_FIPS_BUILDER
+    vars:
+      BUILDARCH:
+        sh: 'docker info --format "{{"{{"}}json .Architecture{{"}}"}}" | tr -d "\"" | sed "s/x86_64/amd64/;s/aarch64/arm64/"'
+    cmds:
+    - for:
+        var: COMPONENTS
+        as: COMPONENT
+      cmd: >
+        docker buildx build
+        --platform linux/{{.BUILDARCH}}
+        --target export
+        --build-arg BUILDARCH={{.BUILDARCH}}
+        --build-arg TARGETOS={{.OS}}
+        --build-arg TARGETARCH={{.ARCH}}
+        --build-arg COMPONENT={{.COMPONENT}}
+        --build-arg VERSION={{.VERSION}}
+        --build-arg GIT_TREE_STATE={{.GIT_TREE_STATE}}
+        --build-arg GIT_COMMIT={{.GIT_COMMIT}}
+        --build-arg BUILD_DATE={{.BUILD_DATE}}
+        --build-arg MODULE_NAME={{.MODULE_NAME}}
+        --output type=local,dest={{.ROOT_DIR2}}/bin
+        -f {{.DOCKERFILE_FIPS_BUILDER}}
+        {{.ROOT_DIR2}}
+
+  build-multi-fips-raw:
+    desc: "  Build FIPS-compliant multi-platform binaries. Skips code generation/validation tasks."
+    requires:
+      vars:
+      - COMPONENTS
+      - ALL_ARCH
+    cmds:
+    - for:
+        matrix:
+          OS: [linux]
+          ARCH:
+            ref: .ALL_ARCH
+      vars:
+        OS: '{{.ITEM.OS}}'
+        ARCH: '{{.ITEM.ARCH}}'
+      task: build-fips-raw
+
+  all-fips:
+    desc: "  Build FIPS-compliant multi-platform binaries."
+    aliases:
+    - build-multi-fips
+    requires:
+      vars:
+      - COMPONENTS
+      - ALL_ARCH
+    cmds:
+    - for:
+        matrix:
+          OS: [linux]
+          ARCH:
+            ref: .ALL_ARCH
+      vars:
+        OS: '{{.ITEM.OS}}'
+        ARCH: '{{.ITEM.ARCH}}'
+      task: build-fips

--- a/tasks_build_img.yaml
+++ b/tasks_build_img.yaml
@@ -30,28 +30,24 @@ tasks:
     internal: true
 
   build:
-    desc: "  Build the image for $IMAGE_OS/$ARCH."
+    desc: "  Build the FIPS-compliant image for $IMAGE_OS/$ARCH."
     summary: |
-      This task builds the image for the current operating system and architecture.
-      To overwrite this, set the 'IMAGE_OS' and 'ARCH' environment variables.
+      Builds the FIPS binary (using Microsoft Go + GOEXPERIMENT=systemcrypto inside Docker)
+      and then packages it into a gardenlinux-fips runtime image.
+      To overwrite the OS/arch, set the 'IMAGE_OS' and 'ARCH' environment variables.
       To overwrite the image's base path, set the 'IMAGE_REGISTRY' environment variable.
-    deps:
-    - task: build:bin:build
+    cmds:
+    - task: build:bin:build-fips-raw
       vars:
         OS: '{{.IMAGE_OS}}'
         ARCH: '{{.ARCH}}'
-    cmds:
     - task: build-raw
       vars:
         OS: '{{.IMAGE_OS}}'
         ARCH: '{{.ARCH}}'
 
   build-raw:
-    desc: "  Build the image. Does not run the binary build before."
-    summary: |
-      This task builds the image for the current operating system and architecture.
-      To overwrite this, set the 'IMAGE_OS' and 'ARCH' environment variables.
-      To overwrite the image's base path, set the 'IMAGE_REGISTRY' environment variable.
+    desc: "  Build the image. Does not build the binary before."
     requires:
       vars:
       - COMPONENTS
@@ -68,7 +64,7 @@ tasks:
       vars:
         COMPONENT: '{{.ITEM}}'
         IMAGE_BASE: '{{.IMAGE_BASE}}'
-        OS: '{{.IMAGE_OS}}'
+        OS: '{{.OS}}'
         ARCH: '{{.ARCH}}'
       task: build-internal
 
@@ -85,9 +81,19 @@ tasks:
       - DOCKERFILE
     cmds:
     - 'echo "Building image {{.COMPONENT}}:{{.VERSION}}-{{.OS}}-{{.ARCH}}"'
-    - '[[ "{{.OS}}" == "linux" ]] || { echo "The distroless base image does only support linux as operating system."; exit 1; }'
+    - '[[ "{{.OS}}" == "linux" ]] || { echo "The gardenlinux-fips base image only supports linux."; exit 1; }'
     - 'cat "{{.DOCKERFILE}}" | sed "s/<component>/{{.COMPONENT}}/g" > "{{.ROOT_DIR2}}/Dockerfile.tmp"'
-    - '( cd "{{.ROOT_DIR2}}"; docker buildx build --builder {{.DOCKER_BUILDER_NAME}} --load --build-arg COMPONENT={{.COMPONENT}} --platform {{.OS}}/{{.ARCH}} -t {{.IMAGE_BASE}}/{{.COMPONENT}}:{{.VERSION}}-{{.OS}}-{{.ARCH}} -f Dockerfile.tmp . )'
+    - >
+      ( cd "{{.ROOT_DIR2}}"; docker buildx build
+      --builder {{.DOCKER_BUILDER_NAME}}
+      --load
+      --platform {{.OS}}/{{.ARCH}}
+      --build-arg TARGETOS={{.OS}}
+      --build-arg TARGETARCH={{.ARCH}}
+      --build-arg COMPONENT={{.COMPONENT}}
+      --build-arg VERSION={{.VERSION}}
+      -t {{.IMAGE_BASE}}/{{.COMPONENT}}:{{.VERSION}}-{{.OS}}-{{.ARCH}}
+      -f Dockerfile.tmp . )
     - 'rm -f "{{.ROOT_DIR2}}/Dockerfile.tmp"'
     internal: true
 
@@ -100,7 +106,7 @@ tasks:
     cmds:
     - for:
         matrix:
-          OS: [linux] # distroless base image only supports linux
+          OS: [linux]
           ARCH:
             ref: .ALL_ARCH
       vars:
@@ -117,7 +123,7 @@ tasks:
     cmds:
     - for:
         matrix:
-          OS: [linux] # distroless base image only supports linux
+          OS: [linux]
           ARCH:
             ref: .ALL_ARCH
       vars:
@@ -174,7 +180,7 @@ tasks:
     cmds:
     - for:
         matrix:
-          OS: [linux] # distroless base image only supports linux
+          OS: [linux]
           ARCH:
             ref: .ALL_ARCH
       vars:
@@ -197,12 +203,164 @@ tasks:
     cmds:
     - for:
         matrix:
-          OS: [linux] # distroless base image only supports linux
+          OS: [linux]
           ARCH:
             ref: .ALL_ARCH
       cmd: 'docker manifest create {{.IMG}} --amend {{.IMG}}-{{.ITEM.OS}}-{{.ITEM.ARCH}}'
     - 'echo "Pushing image {{.IMG}}"'
     - 'docker manifest push {{.IMG}}'
+    internal: true
+
+  verify-fips:
+    desc: "  Verify FIPS compliance of built images."
+    summary: |
+      Runs two artifact-level checks against each built container image:
+      1. The component binary contains the Microsoft Go systemcrypto backend
+         (proves GOEXPERIMENT=systemcrypto was applied at build time).
+      2. The image ships a FIPS-validated OpenSSL library (libcrypto.so) for
+         the binary to dlopen at runtime.
+      Kernel FIPS mode (/proc/sys/crypto/fips_enabled) is a property of the
+      deployment host, not the image, and is therefore not checked here.
+      Images must have been built before running this task.
+    requires:
+      vars:
+      - COMPONENTS
+      - VERSION
+      - ALL_ARCH
+    cmds:
+    - for:
+        matrix:
+          OS: [linux]
+          ARCH:
+            ref: .ALL_ARCH
+      vars:
+        OS: '{{.ITEM.OS}}'
+        ARCH: '{{.ITEM.ARCH}}'
+      task: verify-fips-raw
+
+  verify-fips-raw:
+    desc: "  Verify FIPS compliance for all components for a single OS/ARCH."
+    requires:
+      vars:
+      - COMPONENTS
+      - VERSION
+      - OS
+      - ARCH
+    vars:
+      IMAGE_BASE:
+        sh: 'PROJECT_ROOT="{{.ROOT_DIR2}}" {{.TASKFILE_DIR2}}/get-registry.sh --image'
+    cmds:
+    - for:
+        var: COMPONENTS
+      vars:
+        COMPONENT: '{{.ITEM}}'
+        IMAGE_BASE: '{{.IMAGE_BASE}}'
+        OS: '{{.OS}}'
+        ARCH: '{{.ARCH}}'
+      task: verify-fips-internal
+    internal: true
+
+  verify-fips-internal:
+    desc: "  Verify FIPS compliance for a single component image."
+    silent: true
+    requires:
+      vars:
+      - COMPONENT
+      - VERSION
+      - OS
+      - ARCH
+      - IMAGE_BASE
+    vars:
+      IMG: '{{.IMAGE_BASE}}/{{.COMPONENT}}:{{.VERSION}}-{{.OS}}-{{.ARCH}}'
+    cmds:
+    - 'echo "Verifying FIPS compliance for {{.IMG}}"'
+    # [1/2] systemcrypto backend embedded in binary — runs on the HOST because
+    # gardenlinux-fips does not include `strings` (or any of binutils/coreutils).
+    # We copy the binary out of the image and inspect it with the host toolchain.
+    - |
+      echo "--- [1/2] Go binary is wired to use the system OpenSSL ---"
+      TMP=$(mktemp -d)
+      trap 'rm -rf "$TMP"' EXIT
+      CID=$(docker create --platform {{.OS}}/{{.ARCH}} "{{.IMG}}")
+      docker cp "$CID:/{{.COMPONENT}}" "$TMP/{{.COMPONENT}}" >/dev/null
+      docker rm "$CID" >/dev/null
+      # Microsoft Go's `systemcrypto` build mode compiles a shim into the binary
+      # that dlopens the system OpenSSL at runtime and routes all crypto/* calls
+      # through it. There is no "Microsoft OpenSSL" — the actual crypto lib is
+      # whatever libcrypto.so the runtime image ships (in our case, gardenlinux-fips).
+      # ldd does not reveal this because the linkage happens via dlopen, not at
+      # link time. So we scan the binary for the shim's symbols instead.
+      if command -v strings >/dev/null 2>&1; then
+        SCAN="strings $TMP/{{.COMPONENT}}"
+      else
+        SCAN="grep -aoE [[:print:]]+ $TMP/{{.COMPONENT}}"
+      fi
+      if $SCAN | grep -qE "crypto/internal/backend/openssl|openssl\.provider|openssl\.Hash"; then
+        echo "OK: binary contains the systemcrypto shim — crypto/* calls will be routed to the system OpenSSL"
+      else
+        echo "FAIL: binary does not contain the systemcrypto shim — GOEXPERIMENT=systemcrypto was not applied at build time"
+        exit 1
+      fi
+    # [2/2] OpenSSL is present AND configured for FIPS in the image.
+    # gardenlinux-fips ships an openssl.cnf that loads the FIPS provider and
+    # sets `default_properties = fips=yes`, so every consumer of libcrypto in
+    # the image gets FIPS crypto by default. We verify all three: the library,
+    # the FIPS provider module, and the config wiring.
+    - |
+      docker run --rm --platform {{.OS}}/{{.ARCH}} --entrypoint /bin/sh "{{.IMG}}" -c '
+        echo "--- [2/2] OpenSSL present and FIPS-configured in image ---"
+        fail=0
+
+        # libcrypto/libssl present
+        for lib in /usr/lib/*/libcrypto.so* /usr/lib/*/libssl.so*; do
+          [ -e "$lib" ] && echo "  lib: $lib"
+        done
+        if ! ls /usr/lib/*/libcrypto.so* >/dev/null 2>&1; then
+          echo "FAIL: libcrypto not found — the binary cannot dlopen OpenSSL at runtime"
+          fail=1
+        fi
+
+        # FIPS provider module present
+        if ls /usr/lib/*/ossl-modules/fips.so >/dev/null 2>&1; then
+          echo "  provider: $(ls /usr/lib/*/ossl-modules/fips.so)"
+        else
+          echo "FAIL: fips.so provider module not found in /usr/lib/*/ossl-modules/"
+          fail=1
+        fi
+
+        # openssl.cnf wires up the FIPS provider and defaults to it
+        CNF=/etc/ssl/openssl.cnf
+        if [ ! -e "$CNF" ]; then
+          echo "FAIL: $CNF not found — libcrypto has no config to load the FIPS provider"
+          fail=1
+        else
+          if grep -qE "^\s*fips\s*=\s*fips_sect" "$CNF"; then
+            echo "  config: FIPS provider is registered in $CNF"
+          else
+            echo "FAIL: $CNF does not register the FIPS provider (missing \"fips = fips_sect\")"
+            fail=1
+          fi
+          if grep -qE "^\s*default_properties\s*=\s*fips=yes" "$CNF"; then
+            echo "  config: default_properties = fips=yes"
+          else
+            echo "FAIL: $CNF does not set default_properties = fips=yes — non-FIPS crypto may be used by default"
+            fail=1
+          fi
+        fi
+
+        # openssl CLI cross-check (best-effort — not present in every minimal image)
+        if command -v openssl >/dev/null 2>&1; then
+          if openssl list -providers 2>/dev/null | grep -qE "^\s*fips\s*$"; then
+            echo "  runtime: openssl list -providers reports the fips provider as active"
+          else
+            echo "FAIL: openssl list -providers does not show the fips provider as active"
+            fail=1
+          fi
+        fi
+
+        [ "$fail" = "0" ] || exit 1
+      '
+    - 'echo "FIPS compliance check passed for {{.IMG}}"'
     internal: true
 
   tag:
@@ -226,7 +384,7 @@ tasks:
       cmd: 'docker buildx imagetools create "{{.IMAGE_BASE}}/{{.COMPONENT}}:{{.VERSION}}" --tag "{{.IMAGE_BASE}}/{{.COMPONENT}}:{{.TAG}}"'
 
   all:
-    desc: "  Build binaries and images for multiple operating systems and architectures and push them to the registry."
+    desc: "  Build FIPS-compliant binaries and images for multiple operating systems and architectures and push them to the registry."
     cmds:
     - task: build-multi
     - task: push-multi


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR swaps the Dockerfile base image to `ghcr.io/gardenlinux/gardenlinux-fips`.
In addition a new FIPS binary builder ins integrated in the Taskfiles that builds FIPS 140-3 compatible binaries.
It uses the Microsoft golang toolchain instead of the default golang toolchain.
The reason is that only the Microsoft golang toolchain supports `GOEXPERIMENT=systemcrypto`.
This flag enables linking agains the system openssl instead of the builtin GO crypto modules.
This is important because in our Docker images we want to link agains the openssl library that comes with gardenlinux-fips.
By this we profit from the FIPS certification of the gardenlinux-fips images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Provide FIPS 140-3 compatible images
```
