### PR TITLE
fix: version replacement for versions v2 or greater

### DIFF
--- a/tasks_rls.yaml
+++ b/tasks_rls.yaml
@@ -153,7 +153,7 @@ tasks:
       - MODULE
       - MODULE_NAME
     cmds:
-    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@	{{.MODULE_NAME}}/{{.MODULE}} v.*@	{{.MODULE_NAME}}/{{.MODULE}} {{.VERSION}}@" "{{.ROOT_DIR2}}/go.mod"'
+    - '{{.TASKFILE_DIR2}}/sed.sh -E "s@	{{.MODULE_NAME}}/{{.MODULE}}(/v[0-9]+)? v.*@	{{.MODULE_NAME}}/{{.MODULE}}\1 {{.VERSION}}@" "{{.ROOT_DIR2}}/go.mod"'
     - for:
         var: NESTED_MODULES
       vars:


### PR DESCRIPTION
**What this PR does / why we need it**:
The logic which bumps the api version in nested modules during a release could not handle versions v2 or greater, since they require an additional '/vX' suffix in the module path. This has now been fixed.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
