### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -2,6 +2,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs: 
   test:
     uses: ./.github/workflows/reuse.lib.yaml


### PR DESCRIPTION
Potential fix for [https://github.com/openmcp-project/build/security/code-scanning/2](https://github.com/openmcp-project/build/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/reuse.yaml` at the workflow root (top-level), so it applies to all jobs including the reusable workflow call job (`test`).  
Best minimal, non-breaking choice is:

- `contents: read`

This follows least privilege and avoids changing intended behavior unless write scopes were implicitly relied upon (which is not indicated in the provided snippet).  
Edit region: directly after the `on:` section and before `jobs:`.

No imports, methods, or additional definitions are needed—only YAML key insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
