### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse.lib.yaml
+++ b/.github/workflows/reuse.lib.yaml
@@ -3,6 +3,9 @@ name: REUSE Compliance Check
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openmcp-project/build/security/code-scanning/3](https://github.com/openmcp-project/build/security/code-scanning/3)

Add an explicit top-level `permissions` section in `.github/workflows/reuse.lib.yaml` so all jobs in this reusable workflow inherit minimal token scope.  
Best fix (without changing functionality): insert:

```yaml
permissions:
  contents: read
```

immediately after the `on` block (or before `jobs`). This satisfies CodeQL’s recommendation and preserves behavior for checkout and read-only compliance checks. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
