### PR TITLE
fix: remove -a flag from go build to enable build cache

### DIFF
--- a/tasks_build_bin.yaml
+++ b/tasks_build_bin.yaml
@@ -58,7 +58,7 @@ tasks:
     - for:
         var: COMPONENTS
         as: COMPONENT
-      cmd: 'CGO_ENABLED=0 GOOS={{.OS}} GOARCH={{.ARCH}} go build -a -ldflags="-X {{.MODULE_NAME}}/internal/version.buildVersion={{.VERSION}} -X {{.MODULE_NAME}}/internal/version.gitTreeState={{.GIT_TREE_STATE}} -X {{.MODULE_NAME}}/internal/version.gitCommit={{.GIT_COMMIT}} -X {{.MODULE_NAME}}/internal/version.buildDate={{.BUILD_DATE}}" -o {{.ROOT_DIR2}}/bin/{{.COMPONENT}}.{{.OS}}-{{.ARCH}} {{.ROOT_DIR2}}/cmd/{{.COMPONENT}}/main.go'
+      cmd: 'CGO_ENABLED=0 GOOS={{.OS}} GOARCH={{.ARCH}} go build -ldflags="-X {{.MODULE_NAME}}/internal/version.buildVersion={{.VERSION}} -X {{.MODULE_NAME}}/internal/version.gitTreeState={{.GIT_TREE_STATE}} -X {{.MODULE_NAME}}/internal/version.gitCommit={{.GIT_COMMIT}} -X {{.MODULE_NAME}}/internal/version.buildDate={{.BUILD_DATE}}" -o {{.ROOT_DIR2}}/bin/{{.COMPONENT}}.{{.OS}}-{{.ARCH}} {{.ROOT_DIR2}}/cmd/{{.COMPONENT}}/main.go'
 
   build-multi-raw:
     desc: "  Build multi-platform binaries. Skips code generation/validation tasks."


### PR DESCRIPTION
## Summary

- Remove the `-a` flag from `go build` in `tasks_build_bin.yaml`
- `-a` forces recompilation of **all** packages on every build, defeating the Go build cache
- `CGO_ENABLED=0` already guarantees a static, portable binary — `-a` is redundant here
- This was present since the initial commit with no documented rationale

## Impact

Build times should improve significantly on subsequent builds (local and CI) as the Go build cache is no longer invalidated on every run.

## Test plan

- [x] Verify binary output is identical (same ldflags, same CGO_ENABLED=0 behaviour)
- [ ] Confirm CI passes with cached builds