### PR TITLE
perf(ci): cache tool binaries between runs

### DIFF
--- a/.github/workflows/ci.lib.yaml
+++ b/.github/workflows/ci.lib.yaml
@@ -18,6 +18,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Cache tool binaries
+        uses: actions/cache@v4
+        with:
+          path: bin/
+          key: tools-${{ runner.os }}-${{ hashFiles('hack/common/tasks_tools.yaml') }}
+
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
Tool binaries (`golangci-lint`, `goimports`, `controller-gen`, etc.) are downloaded and compiled from scratch on every CI run, adding ~2 minutes to `task validate`. This caches `bin/` keyed on `tasks_tools.yaml` so subsequent runs skip reinstallation. Cache invalidates automatically whenever a tool version changes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Companion to #172 (removes `-a` flag from `go build`). Together they should cut CI from ~7min down to ~3min on warm cache.

**Release note**:
```other developer
Cache CI tool binaries to speed up validate step (~2min saved per run).
```