### PR TITLE
fix: use grealpath fallback on macOS for GNU --relative-base support

### DIFF
--- a/unfold.sh
+++ b/unfold.sh
@@ -2,6 +2,16 @@
 
 set -euo pipefail
 
+# On macOS, prefer grealpath (GNU coreutils) over the BSD realpath which lacks --relative-base
+if ! realpath --relative-base=/ / &>/dev/null; then
+  if command -v grealpath &>/dev/null; then
+    realpath() { grealpath "$@"; }
+  else
+    echo "error: GNU realpath required (install via 'brew install coreutils')" >&2
+    exit 1
+  fi
+fi
+
 # This is a small helper script that takes a list of paths and unfolds them:
 #   If the path ends with '/...', the path itself (without '/...') and all of its subfolders are printed.
 #   Otherwise, only the path is printed.


### PR DESCRIPTION
**What this PR does / why we need it**:
macOS ships BSD `realpath` which does not support `--relative-base`. This causes `unfold.sh` to fail with `illegal option` on macOS. The fix detects the missing flag at runtime and falls back to `grealpath` (GNU coreutils, available via `brew install coreutils`), or exits with a clear error message.

**Which issue(s) this PR fixes**:
Fixes build failure: `realpath: illegal option -- -` on macOS when running `task build:img:build`.

**Special notes for your reviewer**:
Detection is done via a probe call (`realpath --relative-base=/ /`) so it works on any platform without OS sniffing.

**Release note**:
```bugfix developer
Fix unfold.sh failing on macOS due to BSD realpath lacking --relative-base support
```