### PR TITLE
fix: add assets_path to envtest status check

### DIFF
--- a/tasks_tools.yaml
+++ b/tasks_tools.yaml
@@ -185,6 +185,7 @@ tasks:
     - 'test -x "{{.ENVTEST}}"'
     - test -f {{.LOCALBIN}}/envtest_version
     - 'cat {{.LOCALBIN}}/envtest_version | grep -q "{{.ENVTEST_VERSION}}"'
+    - test -f {{.LOCALBIN}}/assets_path
     cmds:
     - 'GOBIN="{{.LOCALBIN}}" go install sigs.k8s.io/controller-runtime/tools/setup-envtest@{{.ENVTEST_VERSION}}'
     - echo -n "{{.ENVTEST_VERSION}}" > {{.LOCALBIN}}/envtest_version


### PR DESCRIPTION
## Summary
- Add `test -f {{.LOCALBIN}}/assets_path` to the `envtest` task's status checks
- Without it, a cached `setup-envtest` binary causes the task to be "up to date", skipping `setup-envtest use` and leaving `assets_path` unwritten
- This results in `KUBEBUILDER_ASSETS=""` and tests failing with `etcd: no such file or directory`

## Root cause

Introduced by #173 (cache tool binaries between runs), which caches the entire `bin/` directory. The first time CI ran _before_ this fix, `assets_path` was never written into the cache (it only exists after `setup-envtest use` runs). On subsequent runs the cache was restored, the envtest task's 3 status checks all passed (binary exists, version file exists, version matches), so the task was skipped — but `assets_path` was never in the cache to begin with. Result: `KUBEBUILDER_ASSETS` empty, etcd not found, tests fail.

Adding `test -f assets_path` as a 4th status check forces the task to re-run whenever `assets_path` is missing, breaking the stale-cache scenario.

## Test plan
- [ ] CI build passes on a repo with `ENVTEST_REQUIRED: "true"` and a cached envtest install