### PR TITLE
fix: verify envtest assets dir exists, not just assets_path file

### DIFF
--- a/tasks_tools.yaml
+++ b/tasks_tools.yaml
@@ -185,7 +185,7 @@ tasks:
     - 'test -x "{{.ENVTEST}}"'
     - test -f {{.LOCALBIN}}/envtest_version
     - 'cat {{.LOCALBIN}}/envtest_version | grep -q "{{.ENVTEST_VERSION}}"'
-    - test -f {{.LOCALBIN}}/assets_path
+    - 'test -d "$(cat {{.LOCALBIN}}/assets_path)"'
     cmds:
     - 'GOBIN="{{.LOCALBIN}}" go install sigs.k8s.io/controller-runtime/tools/setup-envtest@{{.ENVTEST_VERSION}}'
     - echo -n "{{.ENVTEST_VERSION}}" > {{.LOCALBIN}}/envtest_version


### PR DESCRIPTION
## Problem

`acbf53b` added `test -f assets_path` as a status check for the `envtest` task. This broke CI in consumers (e.g. metrics-operator PR #249):

1. First run: `setup-envtest use` downloads binaries to `~/.local/share/kubebuilder-envtest/k8s/1.30.0-linux-amd64/`, writes that path into `bin/assets_path`. `bin/` is cached.
2. Second run: cache restores `bin/assets_path` → all status checks pass → task skipped → binaries at that path are **gone on the new runner** → `etcd: no such file or directory` → tests fail.

## Fix

Replace the `test -f` check with one that verifies the directory *referenced by* `assets_path` actually exists:

```yaml
- 'test -d "$(cat {{.LOCALBIN}}/assets_path)"'
```

This covers both cases (missing file and stale path) in a single check, and forces `setup-envtest use` to re-run whenever the binary cache is cold.
