### PR TITLE
chore: Add concurrency cancellation to GitHub Actions workflows

### DIFF
--- a/.github/workflows/validate-pr-content.lib.yaml
+++ b/.github/workflows/validate-pr-content.lib.yaml
@@ -20,6 +20,8 @@ jobs:
             exit 0
           fi
 
+          # TODO: when dependabot opens a PR, we might want to skip as well
+          # see https://github.com/openmcp-project/landscaper/pull/58
           REQUIRED_SECTIONS=("\\*\\*What this PR does / why we need it\\*\\*:" "\\*\\*Release note\\*\\*:")
 
           for SECTION in "${REQUIRED_SECTIONS[@]}"; do


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a concurrency block to GitHub Actions workflows so that in-progress runs are automatically cancelled when a new commit is pushed to the same PR.
see issue https://github.com/openmcp-project/service-provider-template/issues/79

**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/service-provider-template/issues/79

**Special notes for your reviewer**:

**Release note**:

```other dependency

```