### PR TITLE
fix: --inline flag of unfold script not working correctly

### DIFF
--- a/unfold.sh
+++ b/unfold.sh
@@ -85,7 +85,7 @@ for f in "$@"; do
           if $inline_printed; then
             echo -n " "
           fi
-          echo -n "$tmp"
+          echo -n "${tmp//$'\n'/ }"
           inline_printed=true
         else
           if $inline_printed; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug in the `unfold.sh` script which causes the script to return multiple directories separated by newline, even if the `--inline` flag is set.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
