### PR TITLE
chore: upgrade msft go to 1.27

### DIFF
--- a/Dockerfile.fips-builder
+++ b/Dockerfile.fips-builder
@@ -18,7 +18,7 @@
 #     -f Dockerfile.fips-builder .
 #
 # The binary is written to bin/<COMPONENT>.linux-fips-<ARCH> on the host.
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26-bookworm
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.27-bookworm
 ARG BUILDARCH
 ARG TARGETOS
 ARG TARGETARCH
@@ -65,7 +65,7 @@ RUN set -eux; \
     esac; \
     CC="$CC" PKG_CONFIG_PATH="$PKG" \
     GOENV=off \
-    CGO_ENABLED=1 GOEXPERIMENT=systemcrypto \
+    CGO_ENABLED=1 \
     CGO_CFLAGS="" CGO_LDFLAGS="" \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a \
         -ldflags="-X ${MODULE_NAME}/internal/version.buildVersion=${VERSION} \


### PR DESCRIPTION
On-behalf-of: @SAP nico.andres@sap.com

**What this PR does / why we need it**:
upgrades msft go image to 1.27

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Version [v.1.27.0-1](https://github.com/microsoft/go/releases/tag/v1.27.0-1 ) throws an error if `GOEXPERIMENT` is set to `systemcrypto`. It is enabled by default anyway.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|refactor|doc|chore|other
- target_group:   user|operator|developer|dependency
-->
```feature user
upgrades msft go image to 1.27
```
